### PR TITLE
Load slice options correctly for backprojection cli.

### DIFF
--- a/python/ouroboros/cli.py
+++ b/python/ouroboros/cli.py
@@ -92,7 +92,9 @@ def handle_slice(args):
 def handle_backproject(args):
     backproject_options = BackprojectOptions.load_from_json(args.options)
 
-    pipeline, input_data = backproject_pipeline(backproject_options, True)
+    slice_options = SliceOptions.load_from_json(backproject_options.slice_options_path)
+ 
+    pipeline, input_data = backproject_pipeline(backproject_options, slice_options, True)
 
     _, error = pipeline.process(input_data)
 


### PR DESCRIPTION
Addesses issue #1 by loading slice options from from slice options parameter listed in the backprojection options json.  (Doesn't do anything about ignoring --verbose or the lack of it).

Worked after local testing.