### PR TITLE
Minor Process Cap

### DIFF
--- a/.github/workflows/pr-tag.yml
+++ b/.github/workflows/pr-tag.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.merge_commit_sha }}
+        ref: ${{ github.ref }}
         fetch-depth: 0
 
     - name: Bump version and push tag

--- a/python/ouroboros/pipeline/backproject_pipeline.py
+++ b/python/ouroboros/pipeline/backproject_pipeline.py
@@ -53,7 +53,7 @@ class BackprojectPipelineStep(PipelineStep):
             )
         )
 
-        self.num_processes = max(processes, 4)
+        self.num_processes = min(processes, 4)
 
     def _process(self, input_data: any) -> tuple[any, None] | tuple[None, any]:
         config, volume_cache, slice_rects, pipeline_input = input_data


### PR DESCRIPTION
Cap process count for backprojection at 4 temporarily as full process count uses too much memory in some situations and 4 can end up using most of the CPU.