### PR TITLE
[codex] Add GPU plugin backend template

### DIFF
--- a/plugins/plugin-template/README.md
+++ b/plugins/plugin-template/README.md
@@ -70,6 +70,19 @@ Remember, these contexts are not available to you through the app's iframe, you 
 
 The default Dockerfile and Docker Compose YAML should be a good starting point. 
 
+GPU-backed plugins should keep CUDA dependencies inside the plugin backend image rather than requiring the core Ouroboros server image to use a GPU base. The template includes an optional CUDA example:
+
+- `backend/Dockerfile.gpu` starts from an NVIDIA CUDA runtime image and installs the same backend requirements.
+- `backend/compose.gpu.yml` is an override that switches the backend build to `Dockerfile.gpu` and requests NVIDIA GPU devices.
+
+Use it locally with:
+
+```
+docker compose -f backend/compose.yml -f backend/compose.gpu.yml up --build
+```
+
+For a packaged GPU plugin, copy the GPU build and device settings into the compose file referenced by `dockerCompose`, or point `dockerCompose` at a GPU-specific compose file that includes those settings.
+
 It is recommended to read the sample `main.py` in `backend`. This goes over a basic FastAPI server, but more importantly, it demonstrates how to use the `Docker Volume Server` (custom to Ouroboros).
 
 Since plugins need to access files from the host file system (plugin frontends usually sends absolute file paths in the host file system), the `Docker Volume Server` provides functionality to copy files to and from a Docker volume (shared between all plugins and the main server). 

--- a/plugins/plugin-template/backend/Dockerfile.gpu
+++ b/plugins/plugin-template/backend/Dockerfile.gpu
@@ -1,0 +1,23 @@
+FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /code
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    python3-venv \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ./requirements.txt /code/requirements.txt
+
+RUN python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir --upgrade -r /code/requirements.txt
+
+COPY ./app /code/app
+
+CMD ["fastapi", "run", "app/main.py", "--port", "8000"]

--- a/plugins/plugin-template/backend/compose.gpu.yml
+++ b/plugins/plugin-template/backend/compose.gpu.yml
@@ -1,0 +1,14 @@
+services:
+  api:
+    build:
+      dockerfile: Dockerfile.gpu
+    environment:
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
+      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]


### PR DESCRIPTION
## Summary

- add an optional CUDA-based `Dockerfile.gpu` to the plugin template
- add a `compose.gpu.yml` override that requests NVIDIA GPU devices for plugin backends
- document how GPU-backed plugins should keep CUDA dependencies in plugin images instead of making the core Ouroboros server image GPU-first

Refs #78

## Validation

- `docker compose -f plugins/plugin-template/backend/compose.yml -f plugins/plugin-template/backend/compose.gpu.yml config`
- `git -C ouroboros diff --check`

## Not run

- GPU container build/run validation was not run locally.