### PR TITLE
[codex] Publish registry-backed server images

### DIFF
--- a/.github/workflows/server-image.yml
+++ b/.github/workflows/server-image.yml
@@ -1,6 +1,10 @@
 name: Publish Server Image
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/server-image.yml
+      - python/**
   push:
     tags:
       - v*.*.*
@@ -42,6 +46,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -57,11 +62,11 @@ jobs:
             type=ref,event=tag
             type=sha,prefix=sha-
 
-      - name: Build and Push Server Image
+      - name: Build Server Image
         uses: docker/build-push-action@v6
         with:
           context: ./python
           file: ./python/Dockerfile-prod
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/server-image.yml
+++ b/.github/workflows/server-image.yml
@@ -1,0 +1,67 @@
+name: Publish Server Image
+
+on:
+  push:
+    tags:
+      - v*.*.*
+  workflow_dispatch:
+
+env:
+  REGISTRY_IMAGE: ghcr.io/chenglabresearch/ouroboros-server
+
+jobs:
+  server-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: '2.1.3'
+
+      - name: Install Python Dependencies
+        working-directory: ./python
+        run: poetry install
+
+      - name: Build Wheel
+        working-directory: ./python
+        run: poetry build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=ref,event=tag
+            type=sha,prefix=sha-
+
+      - name: Build and Push Server Image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./python
+          file: ./python/Dockerfile-prod
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/documentation/docs/development/registry-server-images.md
+++ b/documentation/docs/development/registry-server-images.md
@@ -1,0 +1,28 @@
+# Registry Server Images
+
+Ouroboros can publish the Python server Docker image to GHCR during release-tag workflows. This avoids turning every production startup into a local image build once release packaging is ready to reference immutable image tags.
+
+## Published Image
+
+The `Publish Server Image` workflow builds the Python wheel, builds `python/Dockerfile-prod`, and publishes:
+
+- `ghcr.io/chenglabresearch/ouroboros-server:<release-tag>` for release tags such as `v1.4.0`
+- `ghcr.io/chenglabresearch/ouroboros-server:sha-<commit>` for the exact source revision
+
+Both tags are produced from the same wheel artifact that the Dockerfile installs.
+
+## Release Compose Usage
+
+Release packaging should prefer an immutable image tag when the corresponding image exists:
+
+```yaml
+services:
+  ouroboros-server:
+    image: ghcr.io/chenglabresearch/ouroboros-server:v1.4.0
+```
+
+Keep the bundled wheel and `Dockerfile-prod` path available as a fallback until installers consistently ship a release-specific compose file. Development compose files should keep building locally from source so local edits do not depend on registry state.
+
+## Manual Runs
+
+The workflow also supports `workflow_dispatch` for validating or re-publishing the image from the current branch. Release consumers should still use tag or SHA image references rather than mutable names.

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
     - Python: https://github.com/ChengLabResearch/ouroboros/blob/main/python/README.md
     - Plugins: https://github.com/ChengLabResearch/ouroboros/blob/main/plugins/plugin-template/README.md
     - Docker Builds: 'development/docker-builds.md'
+    - Registry Server Images: 'development/registry-server-images.md'
   - Releases: 'https://github.com/ChengLabResearch/ouroboros/releases'
   - Repository: https://github.com/ChengLabResearch/ouroboros
 


### PR DESCRIPTION
## Summary

- add a `Publish Server Image` workflow that builds the Python wheel and publishes `python/Dockerfile-prod` to GHCR
- tag server images by release tag and commit SHA
- document how release compose files should consume immutable registry image tags while keeping the wheel/Dockerfile path as fallback

Closes #85

## Validation

- `poetry install` in `python/`
- `poetry build` in `python/`
- `docker build -f python/Dockerfile-prod -t ouroboros-server:pr86-build python`
- `docker run --rm ouroboros-server:pr86-build python -c "import ouroboros; print('ouroboros import ok')"`
- GitHub Actions PR checks passed:
  - `coverage`
  - `docs`
  - `server-image`
  - `test-coverage`

## Manual GHCR Publish

- Manually dispatched `Publish Server Image` on `codex/registry-server-images`
- Run: https://github.com/ChengLabResearch/ouroboros/actions/runs/28260409147
- Result: success
- Source commit: `ab3eb073974e8431be68b48b53933298f8f2807c`
- Published image: `ghcr.io/chenglabresearch/ouroboros-server:sha-ab3eb07`
- Published digest: `sha256:f90b106eb798508386c249b24164f982e37a1f1328986e801294faa6bfc46031`
- GitHub Packages API confirms the package exists with tag `sha-ab3eb07`
- Current GHCR package visibility: `public`
- Anonymous registry manifest inspection succeeds for `ghcr.io/chenglabresearch/ouroboros-server:sha-ab3eb07`
