### PR TITLE
Use registry-backed server image in production packages

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -22,54 +22,20 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
-
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install PostgreSQL development headers (Mac)
-        if: matrix.os == 'macos-latest'
-        run: brew install postgresql
-        
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: '2.1.3'
-
-      - name: Install Dependencies
-        working-directory: ./python
-        run: poetry install
-
-      - name: Build Wheel
-        working-directory: ./python
-        run: poetry build
-
-      - name: Copy Python Server Executable Mac or Linux
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-        run: |
-          mkdir -p ./extra-resources/server/dist/
-          cp -r ./python/dist/* ./extra-resources/server/dist/
-          cp ./python/Dockerfile-prod ./extra-resources/server/Dockerfile
-          cp ./python/compose.yml ./extra-resources/server/compose.yml
-
-      - name: Copy Python Server Executable Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          New-Item -Path ./extra-resources/server/dist/ -ItemType Directory -Force
-          Copy-Item -Path ./python/dist/* -Destination ./extra-resources/server/dist/ -Recurse
-          Copy-Item -Path ./python/Dockerfile-prod -Destination ./extra-resources/server/Dockerfile
-          Copy-Item -Path ./python/compose.yml -Destination ./extra-resources/server/compose.yml
-        shell: powershell
+        uses: actions/checkout@v4
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Install Dependencies
         run: npm install
+
+      - name: Prepare registry-backed server resources
+        run: npm run prepare:production-server
+        env:
+          OUROBOROS_SERVER_IMAGE_TAG: ${{ github.ref_name }}
 
       - name: build-linux
         if: matrix.os == 'ubuntu-latest'

--- a/documentation/docs/development/registry-server-images.md
+++ b/documentation/docs/development/registry-server-images.md
@@ -13,15 +13,29 @@ Both tags are produced from the same wheel artifact that the Dockerfile installs
 
 ## Release Compose Usage
 
-Release packaging should prefer an immutable image tag when the corresponding image exists:
+Release packaging uses `npm run prepare:production-server` to write
+`extra-resources/server/compose.yml` and `extra-resources/server/server-image.json`.
+For a tag build, the app package workflow sets:
 
 ```yaml
-services:
-  ouroboros-server:
-    image: ghcr.io/chenglabresearch/ouroboros-server:v1.4.0
+OUROBOROS_SERVER_IMAGE_TAG=v1.4.0
 ```
 
-Keep the bundled wheel and `Dockerfile-prod` path available as a fallback until installers consistently ship a release-specific compose file. Development compose files should keep building locally from source so local edits do not depend on registry state.
+The generated compose file preserves the production ports, `ouroboros-volume`
+mount, `host.docker.internal` mapping, `OUR_ENV=docker`, and `shm_size` settings,
+but uses `image:` instead of `build:`. Production first launch therefore pulls
+the published GHCR image instead of building the server locally.
+
+For digest-pinned packages, set:
+
+```bash
+OUROBOROS_SERVER_IMAGE_REPOSITORY=ghcr.io/chenglabresearch/ouroboros-server
+OUROBOROS_SERVER_IMAGE_DIGEST=sha256:<digest>
+npm run prepare:production-server
+```
+
+Development compose files still build locally from source so local edits do not
+depend on registry state.
 
 ## Manual Runs
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"start": "electron-vite preview",
 		"dev": "electron-vite dev",
 		"build": "npm run typecheck && electron-vite build",
+		"prepare:production-server": "node scripts/prepare-production-server.mjs",
 		"postinstall": "electron-builder install-app-deps",
 		"build:unpack": "npm run build && electron-builder --dir",
 		"build:win": "electron-vite build && electron-builder --win --config --publish never",

--- a/scripts/prepare-production-server.mjs
+++ b/scripts/prepare-production-server.mjs
@@ -1,0 +1,57 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+const outputDir = join(root, 'extra-resources', 'server')
+
+const imageRepository =
+	process.env.OUROBOROS_SERVER_IMAGE_REPOSITORY ??
+	'ghcr.io/chenglabresearch/ouroboros-server'
+const explicitImage = process.env.OUROBOROS_SERVER_IMAGE ?? null
+const imageTag = process.env.OUROBOROS_SERVER_IMAGE_TAG ?? process.env.GITHUB_REF_NAME ?? `v${packageJson.version}`
+const imageDigest = process.env.OUROBOROS_SERVER_IMAGE_DIGEST ?? null
+const image = explicitImage ?? imageReference()
+
+await mkdir(outputDir, { recursive: true })
+await writeFile(join(outputDir, 'compose.yml'), composeForImage(image))
+await writeFile(
+	join(outputDir, 'server-image.json'),
+	`${JSON.stringify(
+		{
+			image,
+			repository: imageRepository,
+			tag: explicitImage || imageDigest ? null : imageTag,
+			digest: imageDigest,
+			commit: process.env.GITHUB_SHA ?? null,
+			ref: process.env.GITHUB_REF_NAME ?? null
+		},
+		null,
+		2
+	)}\n`
+)
+
+function imageReference() {
+	if (imageDigest) return `${imageRepository}@${imageDigest}`
+	return `${imageRepository}:${imageTag}`
+}
+
+function composeForImage(serverImage) {
+	return `services:
+  ouroboros-server:
+    image: ${serverImage}
+    container_name: ouroboros-server
+    ports:
+      - '8000:8000'
+    volumes:
+      - ouroboros-volume:/volume
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - OUR_ENV=docker
+    shm_size: 64gb
+volumes:
+  ouroboros-volume:
+    name: ouroboros-volume
+`
+}


### PR DESCRIPTION
## Summary
- add a production server resource generator that writes extra-resources/server/compose.yml with a GHCR image reference
- include server-image.json metadata for the exact repository/tag/digest used by a package
- update the app release workflow to prepare registry-backed server resources instead of bundling Python wheel/Dockerfile build inputs
- document tag and digest usage for release packaging

## Verification
- node --check scripts/prepare-production-server.mjs
- OUROBOROS_SERVER_IMAGE_TAG=v9.9.9 npm run prepare:production-server
- inspected generated extra-resources/server/compose.yml
- inspected generated extra-resources/server/server-image.json

Closes #88.