### PR TITLE
Install bundled preinstalled plugins on startup

### DIFF
--- a/documentation/docs/guide/plugins.md
+++ b/documentation/docs/guide/plugins.md
@@ -22,6 +22,18 @@
 
 _Where are plugins installed? In the [appData](https://github.com/electron/electron/blob/main/docs/api/app.md#appgetpathname)/ouroboros folder. This folder is different on each OS._
 
+### Preinstalled Production Plugins
+
+Production packages can bundle plugin folders under
+`extra-resources/preinstalled-plugins/<plugin-name>/`. On startup, Ouroboros
+copies missing bundled plugins into the normal user-data plugin folder before it
+loads plugins.
+
+Bundled plugin installs are idempotent and version-aware. If a user already has
+the same plugin installed, Ouroboros compares the `version` field in each
+plugin's `package.json`; it upgrades only when the bundled version is newer and
+skips existing installs that are current, newer, or not safely comparable.
+
 ### Creating a Plugin
 
 See the [template README](https://github.com/ChengLabResearch/ouroboros/blob/main/plugins/plugin-template/README.md) for more information.

--- a/src/main/plugins.ts
+++ b/src/main/plugins.ts
@@ -23,6 +23,113 @@ export async function getPluginFolder(): Promise<string> {
 	return pluginFolder
 }
 
+export function getPreinstalledPluginFolder(): string {
+	return join(__dirname, '../../../extra-resources/preinstalled-plugins')
+}
+
+async function readPluginPackage(pluginFolder: string): Promise<PluginPackageJSON | string> {
+	const pathToPackageJSON = join(pluginFolder, 'package.json')
+
+	if (!existsSync(pathToPackageJSON)) {
+		return `Plugin package.json not found: ${pathToPackageJSON}`
+	}
+
+	const packageJSON = await readFile({ folder: pluginFolder, name: 'package.json' })
+	return parsePluginPackageJSON(packageJSON)
+}
+
+export async function installPreinstalledPlugins(
+	pluginFolder: string,
+	preinstalledPluginFolder = getPreinstalledPluginFolder()
+): Promise<void> {
+	if (!existsSync(preinstalledPluginFolder)) {
+		console.info(`No preinstalled plugin folder found at ${preinstalledPluginFolder}`)
+		return
+	}
+
+	const bundledEntries = await fs.readdir(preinstalledPluginFolder, { withFileTypes: true })
+	for (const entry of bundledEntries) {
+		if (!entry.isDirectory()) continue
+
+		const bundledFolder = join(preinstalledPluginFolder, entry.name)
+		const bundledPackage = await readPluginPackage(bundledFolder)
+		if (typeof bundledPackage === 'string') {
+			console.error(`Skipping bundled plugin ${entry.name}: ${bundledPackage}`)
+			continue
+		}
+
+		const targetFolder = join(pluginFolder, bundledPackage.name)
+		const installAction = await preinstalledPluginInstallAction(targetFolder, bundledPackage)
+
+		if (installAction === 'skip') {
+			console.info(
+				`Skipping bundled plugin ${bundledPackage.name}; installed version is current or newer`
+			)
+			continue
+		}
+
+		if (installAction === 'skip-unversioned') {
+			console.info(
+				`Skipping bundled plugin ${bundledPackage.name}; existing install has no comparable version`
+			)
+			continue
+		}
+
+		await fs.rm(targetFolder, { recursive: true, force: true })
+		await fs.cp(bundledFolder, targetFolder, { recursive: true })
+		console.info(
+			`${installAction === 'upgrade' ? 'Upgraded' : 'Installed'} bundled plugin ${bundledPackage.name} ${bundledPackage.version ?? ''}`.trim()
+		)
+	}
+}
+
+async function preinstalledPluginInstallAction(
+	targetFolder: string,
+	bundledPackage: PluginPackageJSON
+): Promise<'install' | 'upgrade' | 'skip' | 'skip-unversioned'> {
+	if (!existsSync(targetFolder)) {
+		return 'install'
+	}
+
+	const installedPackage = await readPluginPackage(targetFolder)
+	if (typeof installedPackage === 'string') {
+		return 'skip-unversioned'
+	}
+
+	const versionComparison = comparePluginVersions(
+		bundledPackage.version,
+		installedPackage.version
+	)
+	if (versionComparison === null) {
+		return 'skip-unversioned'
+	}
+
+	return versionComparison > 0 ? 'upgrade' : 'skip'
+}
+
+function comparePluginVersions(bundledVersion?: string, installedVersion?: string): number | null {
+	if (!bundledVersion || !installedVersion) return null
+
+	const bundledParts = versionParts(bundledVersion)
+	const installedParts = versionParts(installedVersion)
+	const length = Math.max(bundledParts.length, installedParts.length)
+
+	for (let index = 0; index < length; index += 1) {
+		const bundledPart = bundledParts[index] ?? 0
+		const installedPart = installedParts[index] ?? 0
+		if (bundledPart !== installedPart) return bundledPart - installedPart
+	}
+
+	return bundledVersion.localeCompare(installedVersion)
+}
+
+function versionParts(version: string): number[] {
+	return version
+		.split(/[.-]/)
+		.map((part) => Number.parseInt(part, 10))
+		.filter((part) => Number.isFinite(part))
+}
+
 export async function getPluginList(
 	pluginFolder: string,
 	includeJSON = false
@@ -215,6 +322,7 @@ export type PluginDetail = {
 
 export async function startAllPlugins(): Promise<PluginDetail[]> {
 	const pluginFolder = await getPluginFolder()
+	await installPreinstalledPlugins(pluginFolder)
 	const plugins = await getPluginList(pluginFolder, true)
 
 	const dockerCheck = await checkDocker()

--- a/src/main/schemas.ts
+++ b/src/main/schemas.ts
@@ -3,6 +3,7 @@ import { InferOutput, object, optional, safeParse, string } from 'valibot'
 export const PluginPackageJSONSchema = object({
 	name: string('Plugin name is required'),
 	pluginName: string('Readable plugin name is required'),
+	version: optional(string()),
 	icon: optional(string()),
 	index: string('Plugin index.html file is required'),
 	dockerCompose: optional(string())


### PR DESCRIPTION
## Summary
- add startup installation for plugin folders bundled under extra-resources/preinstalled-plugins
- make bundled installs idempotent and version-aware using plugin package.json version fields
- preserve existing local/downloaded plugin behavior and document production preinstall layout

## Verification
- npm ci
- npm run typecheck:node

Closes #89.