### PR TITLE
Finalize production package pins and flavor names

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -13,20 +13,25 @@ on:
         description: Optional server image digest. Overrides the tag when set.
         required: false
       neuroglancer_plugin_tag:
-        description: Neuroglancer plugin release tag. Defaults to the release tag.
+        description: Neuroglancer plugin release tag. Defaults to the production pin.
         required: false
+        default: v1.0.0
       neuroglancer_plugin_artifact:
-        description: Neuroglancer plugin artifact name. Defaults from the plugin tag.
+        description: Neuroglancer plugin artifact name. Defaults to the production pin.
         required: false
+        default: release.zip
       autoseg_plugin_tag:
-        description: Automatic segmentation plugin release tag. Defaults to the release tag.
+        description: Automatic segmentation plugin release tag. Defaults to the production pin.
         required: false
+        default: v0.4.0-beta
       autoseg_cpu_plugin_artifact:
-        description: CPU automatic segmentation plugin artifact name. Defaults from the plugin tag.
+        description: CPU automatic segmentation plugin artifact name. Defaults to the production pin.
         required: false
+        default: auto-segmentation-v0.4.0-beta-cpu.zip
       autoseg_cuda_plugin_artifact:
-        description: CUDA automatic segmentation plugin artifact name. Defaults from the plugin tag.
+        description: CUDA automatic segmentation plugin artifact name. Defaults to the production pin.
         required: false
+        default: auto-segmentation-v0.4.0-beta-cuda.zip
 
 env: 
   GH_TOKEN: "${{ secrets.OUROBOROS_RELEASE_ASSET_TOKEN || secrets.GITHUB_TOKEN }}"
@@ -45,8 +50,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         package:
           - flavor: core
-          - flavor: plugins-cpu
-          - flavor: plugins-cuda
+          - flavor: with-plugins-cpu
+          - flavor: with-plugins-cuda
 
     steps:
       - name: Check out Git repository
@@ -70,9 +75,9 @@ jobs:
         run: npm run prepare:package-flavor
         env:
           OUROBOROS_PACKAGE_FLAVOR: ${{ matrix.package.flavor }}
-          OUROBOROS_NEUROGLANCER_PLUGIN_TAG: ${{ github.event.inputs.neuroglancer_plugin_tag || github.ref_name }}
+          OUROBOROS_NEUROGLANCER_PLUGIN_TAG: ${{ github.event.inputs.neuroglancer_plugin_tag || 'v1.0.0' }}
           OUROBOROS_NEUROGLANCER_PLUGIN_ARTIFACT: ${{ github.event.inputs.neuroglancer_plugin_artifact }}
-          OUROBOROS_AUTOSEG_PLUGIN_TAG: ${{ github.event.inputs.autoseg_plugin_tag || github.ref_name }}
+          OUROBOROS_AUTOSEG_PLUGIN_TAG: ${{ github.event.inputs.autoseg_plugin_tag || 'v0.4.0-beta' }}
           OUROBOROS_AUTOSEG_CPU_PLUGIN_ARTIFACT: ${{ github.event.inputs.autoseg_cpu_plugin_artifact }}
           OUROBOROS_AUTOSEG_CUDA_PLUGIN_ARTIFACT: ${{ github.event.inputs.autoseg_cuda_plugin_artifact }}
 

--- a/documentation/docs/development/production-package-flavors.md
+++ b/documentation/docs/development/production-package-flavors.md
@@ -5,10 +5,10 @@ desktop runner:
 
 - `core`: Ouroboros only, with the production server compose file pointing at
   the registry-published server image.
-- `plugins-cpu`: the core package plus bundled Neuroglancer and Automatic
+- `with-plugins-cpu`: the core package plus bundled Neuroglancer and Automatic
   Segmentation plugin artifacts. The automatic segmentation plugin uses its CPU
   backend image.
-- `plugins-cuda`: the core package plus bundled Neuroglancer and Automatic
+- `with-plugins-cuda`: the core package plus bundled Neuroglancer and Automatic
   Segmentation plugin artifacts. The automatic segmentation plugin uses its
   CUDA backend image and Docker Compose GPU reservation.
 
@@ -19,21 +19,29 @@ so production packages can ship with plugins already available.
 
 ## Release inputs
 
-Tag releases default every image and plugin artifact to the Ouroboros release
-tag. Manual workflow runs can override these inputs:
+Tag releases default the server image to the Ouroboros release tag and default
+bundled plugins to explicit production pins. Manual workflow runs can override
+these inputs:
 
 - `server_image_tag` or `server_image_digest`
-- `neuroglancer_plugin_tag`
-- `neuroglancer_plugin_artifact`
-- `autoseg_plugin_tag`
-- `autoseg_cpu_plugin_artifact`
-- `autoseg_cuda_plugin_artifact`
+- `neuroglancer_plugin_tag` (default `v1.0.0`)
+- `neuroglancer_plugin_artifact` (default `release.zip`)
+- `autoseg_plugin_tag` (default `v0.4.0-beta`)
+- `autoseg_cpu_plugin_artifact` (default `auto-segmentation-v0.4.0-beta-cpu.zip`)
+- `autoseg_cuda_plugin_artifact` (default `auto-segmentation-v0.4.0-beta-cuda.zip`)
 
-The default plugin artifact names are:
+The current plugin pins are:
 
-- `neuroglancer-plugin-<tag>.zip`
-- `auto-segmentation-<tag>-cpu.zip`
-- `auto-segmentation-<tag>-cuda.zip`
+- Neuroglancer plugin: `ChengLabResearch/neuroglancer-plugin` tag `v1.0.0`,
+  asset `release.zip`
+- Automatic segmentation plugin: `ChengLabResearch/ouroboros_autoseg_plugin`
+  tag `v0.4.0-beta`, assets `auto-segmentation-v0.4.0-beta-cpu.zip` and
+  `auto-segmentation-v0.4.0-beta-cuda.zip`
+
+`extra-resources/package-flavor.json` records the selected package flavor,
+server image metadata, and exact plugin release tag/artifact inputs. When a
+plugin archive includes `plugin-release.json`, its release metadata is copied
+into `package-flavor.json` as well.
 
 If plugin release repositories are private, set
 `OUROBOROS_RELEASE_ASSET_TOKEN` to a token that can read those release assets.
@@ -50,3 +58,5 @@ OUROBOROS_PACKAGE_FLAVOR=core npm run prepare:package-flavor
 
 Plugin flavors can be checked against local release zips by placing them in
 `.package-plugin-artifacts` or setting `OUROBOROS_PLUGIN_ARTIFACT_DIR`.
+Use `OUROBOROS_PACKAGE_FLAVOR=with-plugins-cpu` or
+`OUROBOROS_PACKAGE_FLAVOR=with-plugins-cuda` to stage bundled plugin packages.

--- a/scripts/prepare-package-flavor.mjs
+++ b/scripts/prepare-package-flavor.mjs
@@ -3,7 +3,18 @@ import { existsSync } from 'node:fs'
 import { isAbsolute, join } from 'node:path'
 import { spawn } from 'node:child_process'
 
-const supportedFlavors = new Set(['core', 'plugins-cpu', 'plugins-cuda'])
+const supportedFlavors = new Set(['core', 'with-plugins-cpu', 'with-plugins-cuda'])
+const productionPluginPins = {
+	neuroglancer: {
+		tag: 'v1.0.0',
+		artifact: 'release.zip'
+	},
+	autoseg: {
+		tag: 'v0.4.0-beta',
+		cpuArtifact: 'auto-segmentation-v0.4.0-beta-cpu.zip',
+		cudaArtifact: 'auto-segmentation-v0.4.0-beta-cuda.zip'
+	}
+}
 
 const root = process.cwd()
 const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
@@ -22,7 +33,6 @@ const preinstalledPluginDir = join(extraResourcesDir, 'preinstalled-plugins')
 const artifactDir = resolvePathFromRoot(
 	process.env.OUROBOROS_PLUGIN_ARTIFACT_DIR ?? '.package-plugin-artifacts'
 )
-const releaseTag = process.env.GITHUB_REF_NAME ?? `v${packageJson.version}`
 const plugins = []
 
 await mkdir(extraResourcesDir, { recursive: true })
@@ -31,7 +41,8 @@ await rm(preinstalledPluginDir, { recursive: true, force: true })
 if (flavor !== 'core') {
 	await mkdir(preinstalledPluginDir, { recursive: true })
 
-	const neuroglancerTag = process.env.OUROBOROS_NEUROGLANCER_PLUGIN_TAG || releaseTag
+	const neuroglancerTag =
+		process.env.OUROBOROS_NEUROGLANCER_PLUGIN_TAG || productionPluginPins.neuroglancer.tag
 	await installPlugin({
 		id: 'neuroglancer-plugin',
 		label: 'Neuroglancer',
@@ -39,11 +50,11 @@ if (flavor !== 'core') {
 		tag: neuroglancerTag,
 		artifact:
 			process.env.OUROBOROS_NEUROGLANCER_PLUGIN_ARTIFACT ||
-			`neuroglancer-plugin-${neuroglancerTag}.zip`
+			neuroglancerArtifactForTag(neuroglancerTag)
 	})
 
-	const autosegTag = process.env.OUROBOROS_AUTOSEG_PLUGIN_TAG || releaseTag
-	const autosegVariant = flavor === 'plugins-cuda' ? 'cuda' : 'cpu'
+	const autosegTag = process.env.OUROBOROS_AUTOSEG_PLUGIN_TAG || productionPluginPins.autoseg.tag
+	const autosegVariant = flavor === 'with-plugins-cuda' ? 'cuda' : 'cpu'
 	await installPlugin({
 		id: 'auto-segmentation',
 		label: `Automatic Segmentation (${autosegVariant.toUpperCase()})`,
@@ -51,7 +62,7 @@ if (flavor !== 'core') {
 		tag: autosegTag,
 		artifact:
 			process.env[`OUROBOROS_AUTOSEG_${autosegVariant.toUpperCase()}_PLUGIN_ARTIFACT`] ||
-			`auto-segmentation-${autosegTag}-${autosegVariant}.zip`,
+			autosegArtifactForTag(autosegTag, autosegVariant),
 		variant: autosegVariant
 	})
 }
@@ -82,14 +93,20 @@ async function installPlugin({ id, label, repo, tag, artifact, variant = null })
 	await normalizePluginRoot(target)
 
 	const pluginPackage = await validatePluginPackage(target, id)
+	const releaseManifest = await readPluginReleaseManifest(target, id)
 	plugins.push({
 		id,
 		name: pluginPackage.pluginName,
 		version: pluginPackage.version ?? null,
+		packageVersion: pluginPackage.version ?? null,
+		releaseVersion: releaseManifest?.version ?? null,
 		label,
 		repo,
 		tag,
 		artifact,
+		releaseTag: tag,
+		releaseArtifact: artifact,
+		releaseManifest: summarizeReleaseManifest(releaseManifest),
 		variant
 	})
 }
@@ -177,10 +194,60 @@ async function validatePluginPackage(pluginRoot, expectedId) {
 	return pluginPackage
 }
 
+async function readPluginReleaseManifest(pluginRoot, expectedId) {
+	const manifestPath = join(pluginRoot, 'plugin-release.json')
+	if (!existsSync(manifestPath)) return null
+
+	const releaseManifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+	if (releaseManifest.name && releaseManifest.name !== expectedId) {
+		throw new Error(
+			`Plugin release manifest name mismatch: expected ${expectedId}, found ${releaseManifest.name}`
+		)
+	}
+
+	return releaseManifest
+}
+
+function summarizeReleaseManifest(releaseManifest) {
+	if (!releaseManifest) return null
+
+	return {
+		version: releaseManifest.version ?? null,
+		packageVersion: releaseManifest.packageVersion ?? null,
+		releaseTag: releaseManifest.releaseTag ?? null,
+		artifactName: releaseManifest.artifactName ?? null,
+		variant: releaseManifest.variant ?? null,
+		backendImage: releaseManifest.backendImage ?? null,
+		backendImageRepository: releaseManifest.backendImageRepository ?? null,
+		backendImageTag: releaseManifest.backendImageTag ?? null,
+		cuda: releaseManifest.cuda ?? null,
+		commit: releaseManifest.commit ?? null,
+		ref: releaseManifest.ref ?? null
+	}
+}
+
 async function readServerImageMetadata() {
 	const serverImagePath = join(extraResourcesDir, 'server', 'server-image.json')
 	if (!existsSync(serverImagePath)) return null
 	return JSON.parse(await readFile(serverImagePath, 'utf8'))
+}
+
+function neuroglancerArtifactForTag(tag) {
+	if (tag === productionPluginPins.neuroglancer.tag) {
+		return productionPluginPins.neuroglancer.artifact
+	}
+
+	return `neuroglancer-plugin-${tag}.zip`
+}
+
+function autosegArtifactForTag(tag, variant) {
+	if (tag === productionPluginPins.autoseg.tag) {
+		return variant === 'cuda'
+			? productionPluginPins.autoseg.cudaArtifact
+			: productionPluginPins.autoseg.cpuArtifact
+	}
+
+	return `auto-segmentation-${tag}-${variant}.zip`
 }
 
 function resolvePathFromRoot(path) {


### PR DESCRIPTION
## Summary

Finalizes Ouroboros production package inputs and flavor names.

- Renames package flavors to `core`, `with-plugins-cpu`, and `with-plugins-cuda`.
- Pins bundled plugin versions instead of defaulting plugin tags to the Ouroboros app tag.
- Pins Neuroglancer to `v1.0.0` / `release.zip`.
- Pins automatic segmentation to `v0.4.0-beta` CPU/CUDA assets.
- Records exact plugin release tag/artifact and plugin release metadata in `package-flavor.json`.
- Updates production package flavor documentation.

Addresses ChengLabResearch/ouroboros#93.

## Validation

- `npm run prepare:production-server`
- `npm run prepare:package-flavor`
- `OUROBOROS_PACKAGE_FLAVOR=with-plugins-cpu npm run prepare:package-flavor`
- `OUROBOROS_PACKAGE_FLAVOR=with-plugins-cuda npm run prepare:package-flavor`
- `node --check scripts/prepare-package-flavor.mjs`
- `git diff --check`
