### PR TITLE
Finalize Ouroboros production package bundles

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -22,54 +22,20 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
-
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install PostgreSQL development headers (Mac)
-        if: matrix.os == 'macos-latest'
-        run: brew install postgresql
-        
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: '2.1.3'
-
-      - name: Install Dependencies
-        working-directory: ./python
-        run: poetry install
-
-      - name: Build Wheel
-        working-directory: ./python
-        run: poetry build
-
-      - name: Copy Python Server Executable Mac or Linux
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-        run: |
-          mkdir -p ./extra-resources/server/dist/
-          cp -r ./python/dist/* ./extra-resources/server/dist/
-          cp ./python/Dockerfile-prod ./extra-resources/server/Dockerfile
-          cp ./python/compose.yml ./extra-resources/server/compose.yml
-
-      - name: Copy Python Server Executable Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          New-Item -Path ./extra-resources/server/dist/ -ItemType Directory -Force
-          Copy-Item -Path ./python/dist/* -Destination ./extra-resources/server/dist/ -Recurse
-          Copy-Item -Path ./python/Dockerfile-prod -Destination ./extra-resources/server/Dockerfile
-          Copy-Item -Path ./python/compose.yml -Destination ./extra-resources/server/compose.yml
-        shell: powershell
+        uses: actions/checkout@v4
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Install Dependencies
         run: npm install
+
+      - name: Prepare registry-backed server resources
+        run: npm run prepare:production-server
+        env:
+          OUROBOROS_SERVER_IMAGE_TAG: ${{ github.ref_name }}
 
       - name: build-linux
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -13,20 +13,25 @@ on:
         description: Optional server image digest. Overrides the tag when set.
         required: false
       neuroglancer_plugin_tag:
-        description: Neuroglancer plugin release tag. Defaults to the release tag.
+        description: Neuroglancer plugin release tag. Defaults to the production pin.
         required: false
+        default: v1.0.0
       neuroglancer_plugin_artifact:
-        description: Neuroglancer plugin artifact name. Defaults from the plugin tag.
+        description: Neuroglancer plugin artifact name. Defaults to the production pin.
         required: false
+        default: release.zip
       autoseg_plugin_tag:
-        description: Automatic segmentation plugin release tag. Defaults to the release tag.
+        description: Automatic segmentation plugin release tag. Defaults to the production pin.
         required: false
+        default: v0.4.0-beta
       autoseg_cpu_plugin_artifact:
-        description: CPU automatic segmentation plugin artifact name. Defaults from the plugin tag.
+        description: CPU automatic segmentation plugin artifact name. Defaults to the production pin.
         required: false
+        default: auto-segmentation-v0.4.0-beta-cpu.zip
       autoseg_cuda_plugin_artifact:
-        description: CUDA automatic segmentation plugin artifact name. Defaults from the plugin tag.
+        description: CUDA automatic segmentation plugin artifact name. Defaults to the production pin.
         required: false
+        default: auto-segmentation-v0.4.0-beta-cuda.zip
 
 env: 
   GH_TOKEN: "${{ secrets.OUROBOROS_RELEASE_ASSET_TOKEN || secrets.GITHUB_TOKEN }}"
@@ -45,8 +50,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         package:
           - flavor: core
-          - flavor: plugins-cpu
-          - flavor: plugins-cuda
+          - flavor: with-plugins-cpu
+          - flavor: with-plugins-cuda
 
     steps:
       - name: Check out Git repository
@@ -70,9 +75,9 @@ jobs:
         run: npm run prepare:package-flavor
         env:
           OUROBOROS_PACKAGE_FLAVOR: ${{ matrix.package.flavor }}
-          OUROBOROS_NEUROGLANCER_PLUGIN_TAG: ${{ github.event.inputs.neuroglancer_plugin_tag || github.ref_name }}
+          OUROBOROS_NEUROGLANCER_PLUGIN_TAG: ${{ github.event.inputs.neuroglancer_plugin_tag || 'v1.0.0' }}
           OUROBOROS_NEUROGLANCER_PLUGIN_ARTIFACT: ${{ github.event.inputs.neuroglancer_plugin_artifact }}
-          OUROBOROS_AUTOSEG_PLUGIN_TAG: ${{ github.event.inputs.autoseg_plugin_tag || github.ref_name }}
+          OUROBOROS_AUTOSEG_PLUGIN_TAG: ${{ github.event.inputs.autoseg_plugin_tag || 'v0.4.0-beta' }}
           OUROBOROS_AUTOSEG_CPU_PLUGIN_ARTIFACT: ${{ github.event.inputs.autoseg_cpu_plugin_artifact }}
           OUROBOROS_AUTOSEG_CUDA_PLUGIN_ARTIFACT: ${{ github.event.inputs.autoseg_cuda_plugin_artifact }}
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -40,6 +40,7 @@ jobs:
       contents: write
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         package:
@@ -54,7 +55,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -4,9 +4,32 @@ on:
   push:
     tags:
       - v*.*.*
+  workflow_dispatch:
+    inputs:
+      server_image_tag:
+        description: Server image tag to package. Defaults to the release tag.
+        required: false
+      server_image_digest:
+        description: Optional server image digest. Overrides the tag when set.
+        required: false
+      neuroglancer_plugin_tag:
+        description: Neuroglancer plugin release tag. Defaults to the release tag.
+        required: false
+      neuroglancer_plugin_artifact:
+        description: Neuroglancer plugin artifact name. Defaults from the plugin tag.
+        required: false
+      autoseg_plugin_tag:
+        description: Automatic segmentation plugin release tag. Defaults to the release tag.
+        required: false
+      autoseg_cpu_plugin_artifact:
+        description: CPU automatic segmentation plugin artifact name. Defaults from the plugin tag.
+        required: false
+      autoseg_cuda_plugin_artifact:
+        description: CUDA automatic segmentation plugin artifact name. Defaults from the plugin tag.
+        required: false
 
 env: 
-  GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+  GH_TOKEN: "${{ secrets.OUROBOROS_RELEASE_ASSET_TOKEN || secrets.GITHUB_TOKEN }}"
   GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
 jobs:
@@ -19,6 +42,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        package:
+          - flavor: core
+          - flavor: plugins-cpu
+          - flavor: plugins-cuda
 
     steps:
       - name: Check out Git repository
@@ -35,7 +62,18 @@ jobs:
       - name: Prepare registry-backed server resources
         run: npm run prepare:production-server
         env:
-          OUROBOROS_SERVER_IMAGE_TAG: ${{ github.ref_name }}
+          OUROBOROS_SERVER_IMAGE_TAG: ${{ github.event.inputs.server_image_tag || github.ref_name }}
+          OUROBOROS_SERVER_IMAGE_DIGEST: ${{ github.event.inputs.server_image_digest }}
+
+      - name: Prepare production package flavor
+        run: npm run prepare:package-flavor
+        env:
+          OUROBOROS_PACKAGE_FLAVOR: ${{ matrix.package.flavor }}
+          OUROBOROS_NEUROGLANCER_PLUGIN_TAG: ${{ github.event.inputs.neuroglancer_plugin_tag || github.ref_name }}
+          OUROBOROS_NEUROGLANCER_PLUGIN_ARTIFACT: ${{ github.event.inputs.neuroglancer_plugin_artifact }}
+          OUROBOROS_AUTOSEG_PLUGIN_TAG: ${{ github.event.inputs.autoseg_plugin_tag || github.ref_name }}
+          OUROBOROS_AUTOSEG_CPU_PLUGIN_ARTIFACT: ${{ github.event.inputs.autoseg_cpu_plugin_artifact }}
+          OUROBOROS_AUTOSEG_CUDA_PLUGIN_ARTIFACT: ${{ github.event.inputs.autoseg_cuda_plugin_artifact }}
 
       - name: build-linux
         if: matrix.os == 'ubuntu-latest'
@@ -48,6 +86,11 @@ jobs:
       - name: build-win
         if: matrix.os == 'windows-latest'
         run: npm run build:win
+
+      - name: Add package flavor to artifact names
+        run: npm run rename:release-artifacts
+        env:
+          OUROBOROS_PACKAGE_FLAVOR: ${{ matrix.package.flavor }}
 
       - name: release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -33,11 +33,11 @@ env:
   GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
 jobs:
-  release:
+  build-packages:
     runs-on: ${{ matrix.os }}
 
     permissions:
-      contents: write
+      contents: read
 
     strategy:
       fail-fast: false
@@ -93,11 +93,12 @@ jobs:
         env:
           OUROBOROS_PACKAGE_FLAVOR: ${{ matrix.package.flavor }}
 
-      - name: release
-        uses: softprops/action-gh-release@v1
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
         with:
-          draft: true
-          files: |
+          name: ${{ matrix.os }}-${{ matrix.package.flavor }}-release-assets
+          if-no-files-found: error
+          path: |
             dist/*.exe
             dist/*.zip
             dist/*.dmg
@@ -108,3 +109,33 @@ jobs:
             dist/*.tar.gz
             dist/*.yml
             dist/*.blockmap
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build-packages
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Publish draft release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: |
+            release-assets/*.exe
+            release-assets/*.zip
+            release-assets/*.dmg
+            release-assets/*.AppImage
+            release-assets/*.snap
+            release-assets/*.deb
+            release-assets/*.rpm
+            release-assets/*.tar.gz
+            release-assets/*.yml
+            release-assets/*.blockmap

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out
 *.log*
 documentation/site
 extra-resources
+.package-plugin-artifacts
 data
 ignoreme.py
 temp

--- a/documentation/docs/development/production-package-flavors.md
+++ b/documentation/docs/development/production-package-flavors.md
@@ -1,0 +1,52 @@
+# Production package flavors
+
+The release workflow builds three production package flavors for each supported
+desktop runner:
+
+- `core`: Ouroboros only, with the production server compose file pointing at
+  the registry-published server image.
+- `plugins-cpu`: the core package plus bundled Neuroglancer and Automatic
+  Segmentation plugin artifacts. The automatic segmentation plugin uses its CPU
+  backend image.
+- `plugins-cuda`: the core package plus bundled Neuroglancer and Automatic
+  Segmentation plugin artifacts. The automatic segmentation plugin uses its
+  CUDA backend image and Docker Compose GPU reservation.
+
+Plugin flavors stage release artifacts into
+`extra-resources/preinstalled-plugins` before Electron Builder runs. The app
+installs those bundled plugin folders into the user plugin directory on startup,
+so production packages can ship with plugins already available.
+
+## Release inputs
+
+Tag releases default every image and plugin artifact to the Ouroboros release
+tag. Manual workflow runs can override these inputs:
+
+- `server_image_tag` or `server_image_digest`
+- `neuroglancer_plugin_tag`
+- `neuroglancer_plugin_artifact`
+- `autoseg_plugin_tag`
+- `autoseg_cpu_plugin_artifact`
+- `autoseg_cuda_plugin_artifact`
+
+The default plugin artifact names are:
+
+- `neuroglancer-plugin-<tag>.zip`
+- `auto-segmentation-<tag>-cpu.zip`
+- `auto-segmentation-<tag>-cuda.zip`
+
+If plugin release repositories are private, set
+`OUROBOROS_RELEASE_ASSET_TOKEN` to a token that can read those release assets.
+The workflow falls back to `GITHUB_TOKEN` when that secret is not set.
+
+## Local checks
+
+Prepare the core package resources with:
+
+```sh
+npm run prepare:production-server
+OUROBOROS_PACKAGE_FLAVOR=core npm run prepare:package-flavor
+```
+
+Plugin flavors can be checked against local release zips by placing them in
+`.package-plugin-artifacts` or setting `OUROBOROS_PLUGIN_ARTIFACT_DIR`.

--- a/documentation/docs/development/production-package-flavors.md
+++ b/documentation/docs/development/production-package-flavors.md
@@ -5,10 +5,10 @@ desktop runner:
 
 - `core`: Ouroboros only, with the production server compose file pointing at
   the registry-published server image.
-- `plugins-cpu`: the core package plus bundled Neuroglancer and Automatic
+- `with-plugins-cpu`: the core package plus bundled Neuroglancer and Automatic
   Segmentation plugin artifacts. The automatic segmentation plugin uses its CPU
   backend image.
-- `plugins-cuda`: the core package plus bundled Neuroglancer and Automatic
+- `with-plugins-cuda`: the core package plus bundled Neuroglancer and Automatic
   Segmentation plugin artifacts. The automatic segmentation plugin uses its
   CUDA backend image and Docker Compose GPU reservation.
 
@@ -19,21 +19,29 @@ so production packages can ship with plugins already available.
 
 ## Release inputs
 
-Tag releases default every image and plugin artifact to the Ouroboros release
-tag. Manual workflow runs can override these inputs:
+Tag releases default the server image to the Ouroboros release tag and default
+bundled plugins to explicit production pins. Manual workflow runs can override
+these inputs:
 
 - `server_image_tag` or `server_image_digest`
-- `neuroglancer_plugin_tag`
-- `neuroglancer_plugin_artifact`
-- `autoseg_plugin_tag`
-- `autoseg_cpu_plugin_artifact`
-- `autoseg_cuda_plugin_artifact`
+- `neuroglancer_plugin_tag` (default `v1.0.0`)
+- `neuroglancer_plugin_artifact` (default `release.zip`)
+- `autoseg_plugin_tag` (default `v0.4.0-beta`)
+- `autoseg_cpu_plugin_artifact` (default `auto-segmentation-v0.4.0-beta-cpu.zip`)
+- `autoseg_cuda_plugin_artifact` (default `auto-segmentation-v0.4.0-beta-cuda.zip`)
 
-The default plugin artifact names are:
+The current plugin pins are:
 
-- `neuroglancer-plugin-<tag>.zip`
-- `auto-segmentation-<tag>-cpu.zip`
-- `auto-segmentation-<tag>-cuda.zip`
+- Neuroglancer plugin: `ChengLabResearch/neuroglancer-plugin` tag `v1.0.0`,
+  asset `release.zip`
+- Automatic segmentation plugin: `ChengLabResearch/ouroboros_autoseg_plugin`
+  tag `v0.4.0-beta`, assets `auto-segmentation-v0.4.0-beta-cpu.zip` and
+  `auto-segmentation-v0.4.0-beta-cuda.zip`
+
+`extra-resources/package-flavor.json` records the selected package flavor,
+server image metadata, and exact plugin release tag/artifact inputs. When a
+plugin archive includes `plugin-release.json`, its release metadata is copied
+into `package-flavor.json` as well.
 
 If plugin release repositories are private, set
 `OUROBOROS_RELEASE_ASSET_TOKEN` to a token that can read those release assets.
@@ -50,3 +58,5 @@ OUROBOROS_PACKAGE_FLAVOR=core npm run prepare:package-flavor
 
 Plugin flavors can be checked against local release zips by placing them in
 `.package-plugin-artifacts` or setting `OUROBOROS_PLUGIN_ARTIFACT_DIR`.
+Use `OUROBOROS_PACKAGE_FLAVOR=with-plugins-cpu` or
+`OUROBOROS_PACKAGE_FLAVOR=with-plugins-cuda` to stage bundled plugin packages.

--- a/documentation/docs/development/registry-server-images.md
+++ b/documentation/docs/development/registry-server-images.md
@@ -13,15 +13,29 @@ Both tags are produced from the same wheel artifact that the Dockerfile installs
 
 ## Release Compose Usage
 
-Release packaging should prefer an immutable image tag when the corresponding image exists:
+Release packaging uses `npm run prepare:production-server` to write
+`extra-resources/server/compose.yml` and `extra-resources/server/server-image.json`.
+For a tag build, the app package workflow sets:
 
 ```yaml
-services:
-  ouroboros-server:
-    image: ghcr.io/chenglabresearch/ouroboros-server:v1.4.0
+OUROBOROS_SERVER_IMAGE_TAG=v1.4.0
 ```
 
-Keep the bundled wheel and `Dockerfile-prod` path available as a fallback until installers consistently ship a release-specific compose file. Development compose files should keep building locally from source so local edits do not depend on registry state.
+The generated compose file preserves the production ports, `ouroboros-volume`
+mount, `host.docker.internal` mapping, `OUR_ENV=docker`, and `shm_size` settings,
+but uses `image:` instead of `build:`. Production first launch therefore pulls
+the published GHCR image instead of building the server locally.
+
+For digest-pinned packages, set:
+
+```bash
+OUROBOROS_SERVER_IMAGE_REPOSITORY=ghcr.io/chenglabresearch/ouroboros-server
+OUROBOROS_SERVER_IMAGE_DIGEST=sha256:<digest>
+npm run prepare:production-server
+```
+
+Development compose files still build locally from source so local edits do not
+depend on registry state.
 
 ## Manual Runs
 

--- a/documentation/docs/guide/plugins.md
+++ b/documentation/docs/guide/plugins.md
@@ -22,6 +22,18 @@
 
 _Where are plugins installed? In the [appData](https://github.com/electron/electron/blob/main/docs/api/app.md#appgetpathname)/ouroboros folder. This folder is different on each OS._
 
+### Preinstalled Production Plugins
+
+Production packages can bundle plugin folders under
+`extra-resources/preinstalled-plugins/<plugin-name>/`. On startup, Ouroboros
+copies missing bundled plugins into the normal user-data plugin folder before it
+loads plugins.
+
+Bundled plugin installs are idempotent and version-aware. If a user already has
+the same plugin installed, Ouroboros compares the `version` field in each
+plugin's `package.json`; it upgrades only when the bundled version is newer and
+skips existing installs that are current, newer, or not safely comparable.
+
 ### Creating a Plugin
 
 See the [template README](https://github.com/ChengLabResearch/ouroboros/blob/main/plugins/plugin-template/README.md) for more information.

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
     - Plugins: https://github.com/ChengLabResearch/ouroboros/blob/main/plugins/plugin-template/README.md
     - Docker Builds: 'development/docker-builds.md'
     - Registry Server Images: 'development/registry-server-images.md'
+    - Production Package Flavors: 'development/production-package-flavors.md'
   - Releases: 'https://github.com/ChengLabResearch/ouroboros/releases'
   - Repository: https://github.com/ChengLabResearch/ouroboros
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"start": "electron-vite preview",
 		"dev": "electron-vite dev",
 		"build": "npm run typecheck && electron-vite build",
+		"prepare:production-server": "node scripts/prepare-production-server.mjs",
 		"postinstall": "electron-builder install-app-deps",
 		"build:unpack": "npm run build && electron-builder --dir",
 		"build:win": "electron-vite build && electron-builder --win --config --publish never",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
 		"dev": "electron-vite dev",
 		"build": "npm run typecheck && electron-vite build",
 		"prepare:production-server": "node scripts/prepare-production-server.mjs",
+		"prepare:package-flavor": "node scripts/prepare-package-flavor.mjs",
+		"rename:release-artifacts": "node scripts/rename-release-artifacts.mjs",
 		"postinstall": "electron-builder install-app-deps",
 		"build:unpack": "npm run build && electron-builder --dir",
 		"build:win": "electron-vite build && electron-builder --win --config --publish never",

--- a/scripts/prepare-package-flavor.mjs
+++ b/scripts/prepare-package-flavor.mjs
@@ -3,7 +3,18 @@ import { existsSync } from 'node:fs'
 import { isAbsolute, join } from 'node:path'
 import { spawn } from 'node:child_process'
 
-const supportedFlavors = new Set(['core', 'plugins-cpu', 'plugins-cuda'])
+const supportedFlavors = new Set(['core', 'with-plugins-cpu', 'with-plugins-cuda'])
+const productionPluginPins = {
+	neuroglancer: {
+		tag: 'v1.0.0',
+		artifact: 'release.zip'
+	},
+	autoseg: {
+		tag: 'v0.4.0-beta',
+		cpuArtifact: 'auto-segmentation-v0.4.0-beta-cpu.zip',
+		cudaArtifact: 'auto-segmentation-v0.4.0-beta-cuda.zip'
+	}
+}
 
 const root = process.cwd()
 const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
@@ -22,7 +33,6 @@ const preinstalledPluginDir = join(extraResourcesDir, 'preinstalled-plugins')
 const artifactDir = resolvePathFromRoot(
 	process.env.OUROBOROS_PLUGIN_ARTIFACT_DIR ?? '.package-plugin-artifacts'
 )
-const releaseTag = process.env.GITHUB_REF_NAME ?? `v${packageJson.version}`
 const plugins = []
 
 await mkdir(extraResourcesDir, { recursive: true })
@@ -31,7 +41,8 @@ await rm(preinstalledPluginDir, { recursive: true, force: true })
 if (flavor !== 'core') {
 	await mkdir(preinstalledPluginDir, { recursive: true })
 
-	const neuroglancerTag = process.env.OUROBOROS_NEUROGLANCER_PLUGIN_TAG || releaseTag
+	const neuroglancerTag =
+		process.env.OUROBOROS_NEUROGLANCER_PLUGIN_TAG || productionPluginPins.neuroglancer.tag
 	await installPlugin({
 		id: 'neuroglancer-plugin',
 		label: 'Neuroglancer',
@@ -39,11 +50,11 @@ if (flavor !== 'core') {
 		tag: neuroglancerTag,
 		artifact:
 			process.env.OUROBOROS_NEUROGLANCER_PLUGIN_ARTIFACT ||
-			`neuroglancer-plugin-${neuroglancerTag}.zip`
+			neuroglancerArtifactForTag(neuroglancerTag)
 	})
 
-	const autosegTag = process.env.OUROBOROS_AUTOSEG_PLUGIN_TAG || releaseTag
-	const autosegVariant = flavor === 'plugins-cuda' ? 'cuda' : 'cpu'
+	const autosegTag = process.env.OUROBOROS_AUTOSEG_PLUGIN_TAG || productionPluginPins.autoseg.tag
+	const autosegVariant = flavor === 'with-plugins-cuda' ? 'cuda' : 'cpu'
 	await installPlugin({
 		id: 'auto-segmentation',
 		label: `Automatic Segmentation (${autosegVariant.toUpperCase()})`,
@@ -51,7 +62,7 @@ if (flavor !== 'core') {
 		tag: autosegTag,
 		artifact:
 			process.env[`OUROBOROS_AUTOSEG_${autosegVariant.toUpperCase()}_PLUGIN_ARTIFACT`] ||
-			`auto-segmentation-${autosegTag}-${autosegVariant}.zip`,
+			autosegArtifactForTag(autosegTag, autosegVariant),
 		variant: autosegVariant
 	})
 }
@@ -82,14 +93,20 @@ async function installPlugin({ id, label, repo, tag, artifact, variant = null })
 	await normalizePluginRoot(target)
 
 	const pluginPackage = await validatePluginPackage(target, id)
+	const releaseManifest = await readPluginReleaseManifest(target, id)
 	plugins.push({
 		id,
 		name: pluginPackage.pluginName,
 		version: pluginPackage.version ?? null,
+		packageVersion: pluginPackage.version ?? null,
+		releaseVersion: releaseManifest?.version ?? null,
 		label,
 		repo,
 		tag,
 		artifact,
+		releaseTag: tag,
+		releaseArtifact: artifact,
+		releaseManifest: summarizeReleaseManifest(releaseManifest),
 		variant
 	})
 }
@@ -177,10 +194,60 @@ async function validatePluginPackage(pluginRoot, expectedId) {
 	return pluginPackage
 }
 
+async function readPluginReleaseManifest(pluginRoot, expectedId) {
+	const manifestPath = join(pluginRoot, 'plugin-release.json')
+	if (!existsSync(manifestPath)) return null
+
+	const releaseManifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+	if (releaseManifest.name && releaseManifest.name !== expectedId) {
+		throw new Error(
+			`Plugin release manifest name mismatch: expected ${expectedId}, found ${releaseManifest.name}`
+		)
+	}
+
+	return releaseManifest
+}
+
+function summarizeReleaseManifest(releaseManifest) {
+	if (!releaseManifest) return null
+
+	return {
+		version: releaseManifest.version ?? null,
+		packageVersion: releaseManifest.packageVersion ?? null,
+		releaseTag: releaseManifest.releaseTag ?? null,
+		artifactName: releaseManifest.artifactName ?? null,
+		variant: releaseManifest.variant ?? null,
+		backendImage: releaseManifest.backendImage ?? null,
+		backendImageRepository: releaseManifest.backendImageRepository ?? null,
+		backendImageTag: releaseManifest.backendImageTag ?? null,
+		cuda: releaseManifest.cuda ?? null,
+		commit: releaseManifest.commit ?? null,
+		ref: releaseManifest.ref ?? null
+	}
+}
+
 async function readServerImageMetadata() {
 	const serverImagePath = join(extraResourcesDir, 'server', 'server-image.json')
 	if (!existsSync(serverImagePath)) return null
 	return JSON.parse(await readFile(serverImagePath, 'utf8'))
+}
+
+function neuroglancerArtifactForTag(tag) {
+	if (tag === productionPluginPins.neuroglancer.tag) {
+		return productionPluginPins.neuroglancer.artifact
+	}
+
+	return `neuroglancer-plugin-${tag}.zip`
+}
+
+function autosegArtifactForTag(tag, variant) {
+	if (tag === productionPluginPins.autoseg.tag) {
+		return variant === 'cuda'
+			? productionPluginPins.autoseg.cudaArtifact
+			: productionPluginPins.autoseg.cpuArtifact
+	}
+
+	return `auto-segmentation-${tag}-${variant}.zip`
 }
 
 function resolvePathFromRoot(path) {

--- a/scripts/prepare-package-flavor.mjs
+++ b/scripts/prepare-package-flavor.mjs
@@ -1,0 +1,217 @@
+import { mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { isAbsolute, join } from 'node:path'
+import { spawn } from 'node:child_process'
+
+const supportedFlavors = new Set(['core', 'plugins-cpu', 'plugins-cuda'])
+
+const root = process.cwd()
+const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+const flavor = process.env.OUROBOROS_PACKAGE_FLAVOR ?? 'core'
+
+if (!supportedFlavors.has(flavor)) {
+	throw new Error(
+		`Unsupported OUROBOROS_PACKAGE_FLAVOR "${flavor}". Expected one of: ${[
+			...supportedFlavors
+		].join(', ')}`
+	)
+}
+
+const extraResourcesDir = join(root, 'extra-resources')
+const preinstalledPluginDir = join(extraResourcesDir, 'preinstalled-plugins')
+const artifactDir = resolvePathFromRoot(
+	process.env.OUROBOROS_PLUGIN_ARTIFACT_DIR ?? '.package-plugin-artifacts'
+)
+const releaseTag = process.env.GITHUB_REF_NAME ?? `v${packageJson.version}`
+const plugins = []
+
+await mkdir(extraResourcesDir, { recursive: true })
+await rm(preinstalledPluginDir, { recursive: true, force: true })
+
+if (flavor !== 'core') {
+	await mkdir(preinstalledPluginDir, { recursive: true })
+
+	const neuroglancerTag = process.env.OUROBOROS_NEUROGLANCER_PLUGIN_TAG || releaseTag
+	await installPlugin({
+		id: 'neuroglancer-plugin',
+		label: 'Neuroglancer',
+		repo: 'ChengLabResearch/neuroglancer-plugin',
+		tag: neuroglancerTag,
+		artifact:
+			process.env.OUROBOROS_NEUROGLANCER_PLUGIN_ARTIFACT ||
+			`neuroglancer-plugin-${neuroglancerTag}.zip`
+	})
+
+	const autosegTag = process.env.OUROBOROS_AUTOSEG_PLUGIN_TAG || releaseTag
+	const autosegVariant = flavor === 'plugins-cuda' ? 'cuda' : 'cpu'
+	await installPlugin({
+		id: 'auto-segmentation',
+		label: `Automatic Segmentation (${autosegVariant.toUpperCase()})`,
+		repo: 'ChengLabResearch/ouroboros_autoseg_plugin',
+		tag: autosegTag,
+		artifact:
+			process.env[`OUROBOROS_AUTOSEG_${autosegVariant.toUpperCase()}_PLUGIN_ARTIFACT`] ||
+			`auto-segmentation-${autosegTag}-${autosegVariant}.zip`,
+		variant: autosegVariant
+	})
+}
+
+await writeFile(
+	join(extraResourcesDir, 'package-flavor.json'),
+	`${JSON.stringify(
+		{
+			flavor,
+			appVersion: packageJson.version,
+			serverImage: await readServerImageMetadata(),
+			plugins,
+			commit: process.env.GITHUB_SHA ?? null,
+			ref: process.env.GITHUB_REF_NAME ?? null
+		},
+		null,
+		2
+	)}\n`
+)
+
+async function installPlugin({ id, label, repo, tag, artifact, variant = null }) {
+	const artifactPath = await resolveArtifact({ repo, tag, artifact })
+	const target = join(preinstalledPluginDir, id)
+
+	await rm(target, { recursive: true, force: true })
+	await mkdir(target, { recursive: true })
+	await extractZip(artifactPath, target)
+	await normalizePluginRoot(target)
+
+	const pluginPackage = await validatePluginPackage(target, id)
+	plugins.push({
+		id,
+		name: pluginPackage.pluginName,
+		version: pluginPackage.version ?? null,
+		label,
+		repo,
+		tag,
+		artifact,
+		variant
+	})
+}
+
+async function resolveArtifact({ repo, tag, artifact }) {
+	await mkdir(artifactDir, { recursive: true })
+
+	const artifactPath = join(artifactDir, artifact)
+	if (existsSync(artifactPath)) return artifactPath
+
+	await run('gh', [
+		'release',
+		'download',
+		tag,
+		'--repo',
+		repo,
+		'--pattern',
+		artifact,
+		'--dir',
+		artifactDir,
+		'--clobber'
+	])
+
+	if (!existsSync(artifactPath)) {
+		throw new Error(`Expected release asset was not downloaded: ${repo} ${tag} ${artifact}`)
+	}
+
+	return artifactPath
+}
+
+async function normalizePluginRoot(target) {
+	if (existsSync(join(target, 'package.json'))) return
+
+	const packageRoot = await findPackageRoot(target)
+	if (!packageRoot || packageRoot === target) return
+
+	const normalizedTarget = `${target}.normalized`
+	await rm(normalizedTarget, { recursive: true, force: true })
+	await rename(packageRoot, normalizedTarget)
+	await rm(target, { recursive: true, force: true })
+	await rename(normalizedTarget, target)
+}
+
+async function findPackageRoot(directory, depth = 0) {
+	if (existsSync(join(directory, 'package.json'))) return directory
+	if (depth >= 2) return null
+
+	const entries = await readdir(directory, { withFileTypes: true })
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue
+
+		const found = await findPackageRoot(join(directory, entry.name), depth + 1)
+		if (found) return found
+	}
+
+	return null
+}
+
+async function validatePluginPackage(pluginRoot, expectedId) {
+	const packagePath = join(pluginRoot, 'package.json')
+	if (!existsSync(packagePath)) {
+		throw new Error(`Plugin artifact for ${expectedId} does not contain package.json`)
+	}
+
+	const pluginPackage = JSON.parse(await readFile(packagePath, 'utf8'))
+	if (pluginPackage.name !== expectedId) {
+		throw new Error(
+			`Plugin artifact name mismatch: expected ${expectedId}, found ${pluginPackage.name}`
+		)
+	}
+
+	if (!pluginPackage.index || !existsSync(join(pluginRoot, pluginPackage.index))) {
+		throw new Error(`Plugin artifact for ${expectedId} does not contain ${pluginPackage.index}`)
+	}
+
+	if (
+		pluginPackage.dockerCompose &&
+		!existsSync(join(pluginRoot, pluginPackage.dockerCompose))
+	) {
+		throw new Error(
+			`Plugin artifact for ${expectedId} does not contain ${pluginPackage.dockerCompose}`
+		)
+	}
+
+	return pluginPackage
+}
+
+async function readServerImageMetadata() {
+	const serverImagePath = join(extraResourcesDir, 'server', 'server-image.json')
+	if (!existsSync(serverImagePath)) return null
+	return JSON.parse(await readFile(serverImagePath, 'utf8'))
+}
+
+function resolvePathFromRoot(path) {
+	return isAbsolute(path) ? path : join(root, path)
+}
+
+async function extractZip(artifactPath, target) {
+	if (process.platform === 'win32') {
+		await run('powershell', [
+			'-NoProfile',
+			'-Command',
+			'Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force',
+			artifactPath,
+			target
+		])
+		return
+	}
+
+	await run('unzip', ['-q', artifactPath, '-d', target])
+}
+
+async function run(command, args) {
+	await new Promise((resolve, reject) => {
+		const child = spawn(command, args, { stdio: 'inherit' })
+		child.on('error', reject)
+		child.on('close', (code) => {
+			if (code === 0) {
+				resolve()
+			} else {
+				reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`))
+			}
+		})
+	})
+}

--- a/scripts/prepare-package-flavor.mjs
+++ b/scripts/prepare-package-flavor.mjs
@@ -189,13 +189,7 @@ function resolvePathFromRoot(path) {
 
 async function extractZip(artifactPath, target) {
 	if (process.platform === 'win32') {
-		await run('powershell', [
-			'-NoProfile',
-			'-Command',
-			'param($source, $destination) Expand-Archive -LiteralPath $source -DestinationPath $destination -Force',
-			artifactPath,
-			target
-		])
+		await run('tar', ['-xf', artifactPath, '-C', target])
 		return
 	}
 

--- a/scripts/prepare-package-flavor.mjs
+++ b/scripts/prepare-package-flavor.mjs
@@ -192,7 +192,7 @@ async function extractZip(artifactPath, target) {
 		await run('powershell', [
 			'-NoProfile',
 			'-Command',
-			'Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force',
+			'param($source, $destination) Expand-Archive -LiteralPath $source -DestinationPath $destination -Force',
 			artifactPath,
 			target
 		])

--- a/scripts/prepare-production-server.mjs
+++ b/scripts/prepare-production-server.mjs
@@ -1,0 +1,57 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+const outputDir = join(root, 'extra-resources', 'server')
+
+const imageRepository =
+	process.env.OUROBOROS_SERVER_IMAGE_REPOSITORY ??
+	'ghcr.io/chenglabresearch/ouroboros-server'
+const explicitImage = process.env.OUROBOROS_SERVER_IMAGE ?? null
+const imageTag = process.env.OUROBOROS_SERVER_IMAGE_TAG ?? process.env.GITHUB_REF_NAME ?? `v${packageJson.version}`
+const imageDigest = process.env.OUROBOROS_SERVER_IMAGE_DIGEST ?? null
+const image = explicitImage ?? imageReference()
+
+await mkdir(outputDir, { recursive: true })
+await writeFile(join(outputDir, 'compose.yml'), composeForImage(image))
+await writeFile(
+	join(outputDir, 'server-image.json'),
+	`${JSON.stringify(
+		{
+			image,
+			repository: imageRepository,
+			tag: explicitImage || imageDigest ? null : imageTag,
+			digest: imageDigest,
+			commit: process.env.GITHUB_SHA ?? null,
+			ref: process.env.GITHUB_REF_NAME ?? null
+		},
+		null,
+		2
+	)}\n`
+)
+
+function imageReference() {
+	if (imageDigest) return `${imageRepository}@${imageDigest}`
+	return `${imageRepository}:${imageTag}`
+}
+
+function composeForImage(serverImage) {
+	return `services:
+  ouroboros-server:
+    image: ${serverImage}
+    container_name: ouroboros-server
+    ports:
+      - '8000:8000'
+    volumes:
+      - ouroboros-volume:/volume
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - OUR_ENV=docker
+    shm_size: 64gb
+volumes:
+  ouroboros-volume:
+    name: ouroboros-volume
+`
+}

--- a/scripts/rename-release-artifacts.mjs
+++ b/scripts/rename-release-artifacts.mjs
@@ -5,6 +5,16 @@ const root = process.cwd()
 const dist = join(root, 'dist')
 const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
 const flavor = process.env.OUROBOROS_PACKAGE_FLAVOR
+const dashedPrefixes = unique(
+	[packageJson.name, packageJson.productName]
+		.filter(Boolean)
+		.map((name) => `${name}-${packageJson.version}`)
+)
+const underscoredPrefixes = unique(
+	[packageJson.name, packageJson.productName]
+		.filter(Boolean)
+		.map((name) => `${name}_${packageJson.version}`)
+)
 
 if (!flavor) {
 	console.log('OUROBOROS_PACKAGE_FLAVOR is not set; leaving release artifact names unchanged.')
@@ -49,15 +59,21 @@ function artifactNameForFlavor(fileName) {
 		return `${fileName.slice(0, -'.yml'.length)}-${flavor}.yml`
 	}
 
-	const dashedPrefix = `${packageJson.name}-${packageJson.version}`
-	if (fileName.startsWith(dashedPrefix)) {
-		return `${dashedPrefix}-${flavor}${fileName.slice(dashedPrefix.length)}`
+	for (const dashedPrefix of dashedPrefixes) {
+		if (fileName.startsWith(dashedPrefix)) {
+			return `${dashedPrefix}-${flavor}${fileName.slice(dashedPrefix.length)}`
+		}
 	}
 
-	const underscoredPrefix = `${packageJson.name}_${packageJson.version}`
-	if (fileName.startsWith(underscoredPrefix)) {
-		return `${underscoredPrefix}_${flavor}${fileName.slice(underscoredPrefix.length)}`
+	for (const underscoredPrefix of underscoredPrefixes) {
+		if (fileName.startsWith(underscoredPrefix)) {
+			return `${underscoredPrefix}_${flavor}${fileName.slice(underscoredPrefix.length)}`
+		}
 	}
 
 	return null
+}
+
+function unique(values) {
+	return [...new Set(values)]
 }

--- a/scripts/rename-release-artifacts.mjs
+++ b/scripts/rename-release-artifacts.mjs
@@ -1,0 +1,63 @@
+import { readFile, readdir, rename, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const dist = join(root, 'dist')
+const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+const flavor = process.env.OUROBOROS_PACKAGE_FLAVOR
+
+if (!flavor) {
+	console.log('OUROBOROS_PACKAGE_FLAVOR is not set; leaving release artifact names unchanged.')
+	process.exit(0)
+}
+
+const entries = await readdir(dist, { withFileTypes: true })
+const renameMap = new Map()
+
+for (const entry of entries) {
+	if (!entry.isFile()) continue
+
+	const nextName = artifactNameForFlavor(entry.name)
+	if (!nextName || nextName === entry.name) continue
+
+	renameMap.set(entry.name, nextName)
+}
+
+for (const [oldName, newName] of renameMap) {
+	await rename(join(dist, oldName), join(dist, newName))
+	console.log(`Renamed ${oldName} -> ${newName}`)
+}
+
+const updatedEntries = await readdir(dist, { withFileTypes: true })
+for (const entry of updatedEntries) {
+	if (!entry.isFile() || !entry.name.endsWith('.yml')) continue
+
+	const path = join(dist, entry.name)
+	let text = await readFile(path, 'utf8')
+
+	for (const [oldName, newName] of renameMap) {
+		text = text.split(oldName).join(newName)
+	}
+
+	await writeFile(path, text)
+}
+
+function artifactNameForFlavor(fileName) {
+	if (fileName.includes(`-${flavor}`) || fileName.includes(`_${flavor}`)) return null
+
+	if (fileName.startsWith('latest') && fileName.endsWith('.yml')) {
+		return `${fileName.slice(0, -'.yml'.length)}-${flavor}.yml`
+	}
+
+	const dashedPrefix = `${packageJson.name}-${packageJson.version}`
+	if (fileName.startsWith(dashedPrefix)) {
+		return `${dashedPrefix}-${flavor}${fileName.slice(dashedPrefix.length)}`
+	}
+
+	const underscoredPrefix = `${packageJson.name}_${packageJson.version}`
+	if (fileName.startsWith(underscoredPrefix)) {
+		return `${underscoredPrefix}_${flavor}${fileName.slice(underscoredPrefix.length)}`
+	}
+
+	return null
+}

--- a/src/main/plugins.ts
+++ b/src/main/plugins.ts
@@ -23,6 +23,113 @@ export async function getPluginFolder(): Promise<string> {
 	return pluginFolder
 }
 
+export function getPreinstalledPluginFolder(): string {
+	return join(__dirname, '../../../extra-resources/preinstalled-plugins')
+}
+
+async function readPluginPackage(pluginFolder: string): Promise<PluginPackageJSON | string> {
+	const pathToPackageJSON = join(pluginFolder, 'package.json')
+
+	if (!existsSync(pathToPackageJSON)) {
+		return `Plugin package.json not found: ${pathToPackageJSON}`
+	}
+
+	const packageJSON = await readFile({ folder: pluginFolder, name: 'package.json' })
+	return parsePluginPackageJSON(packageJSON)
+}
+
+export async function installPreinstalledPlugins(
+	pluginFolder: string,
+	preinstalledPluginFolder = getPreinstalledPluginFolder()
+): Promise<void> {
+	if (!existsSync(preinstalledPluginFolder)) {
+		console.info(`No preinstalled plugin folder found at ${preinstalledPluginFolder}`)
+		return
+	}
+
+	const bundledEntries = await fs.readdir(preinstalledPluginFolder, { withFileTypes: true })
+	for (const entry of bundledEntries) {
+		if (!entry.isDirectory()) continue
+
+		const bundledFolder = join(preinstalledPluginFolder, entry.name)
+		const bundledPackage = await readPluginPackage(bundledFolder)
+		if (typeof bundledPackage === 'string') {
+			console.error(`Skipping bundled plugin ${entry.name}: ${bundledPackage}`)
+			continue
+		}
+
+		const targetFolder = join(pluginFolder, bundledPackage.name)
+		const installAction = await preinstalledPluginInstallAction(targetFolder, bundledPackage)
+
+		if (installAction === 'skip') {
+			console.info(
+				`Skipping bundled plugin ${bundledPackage.name}; installed version is current or newer`
+			)
+			continue
+		}
+
+		if (installAction === 'skip-unversioned') {
+			console.info(
+				`Skipping bundled plugin ${bundledPackage.name}; existing install has no comparable version`
+			)
+			continue
+		}
+
+		await fs.rm(targetFolder, { recursive: true, force: true })
+		await fs.cp(bundledFolder, targetFolder, { recursive: true })
+		console.info(
+			`${installAction === 'upgrade' ? 'Upgraded' : 'Installed'} bundled plugin ${bundledPackage.name} ${bundledPackage.version ?? ''}`.trim()
+		)
+	}
+}
+
+async function preinstalledPluginInstallAction(
+	targetFolder: string,
+	bundledPackage: PluginPackageJSON
+): Promise<'install' | 'upgrade' | 'skip' | 'skip-unversioned'> {
+	if (!existsSync(targetFolder)) {
+		return 'install'
+	}
+
+	const installedPackage = await readPluginPackage(targetFolder)
+	if (typeof installedPackage === 'string') {
+		return 'skip-unversioned'
+	}
+
+	const versionComparison = comparePluginVersions(
+		bundledPackage.version,
+		installedPackage.version
+	)
+	if (versionComparison === null) {
+		return 'skip-unversioned'
+	}
+
+	return versionComparison > 0 ? 'upgrade' : 'skip'
+}
+
+function comparePluginVersions(bundledVersion?: string, installedVersion?: string): number | null {
+	if (!bundledVersion || !installedVersion) return null
+
+	const bundledParts = versionParts(bundledVersion)
+	const installedParts = versionParts(installedVersion)
+	const length = Math.max(bundledParts.length, installedParts.length)
+
+	for (let index = 0; index < length; index += 1) {
+		const bundledPart = bundledParts[index] ?? 0
+		const installedPart = installedParts[index] ?? 0
+		if (bundledPart !== installedPart) return bundledPart - installedPart
+	}
+
+	return bundledVersion.localeCompare(installedVersion)
+}
+
+function versionParts(version: string): number[] {
+	return version
+		.split(/[.-]/)
+		.map((part) => Number.parseInt(part, 10))
+		.filter((part) => Number.isFinite(part))
+}
+
 export async function getPluginList(
 	pluginFolder: string,
 	includeJSON = false
@@ -215,6 +322,7 @@ export type PluginDetail = {
 
 export async function startAllPlugins(): Promise<PluginDetail[]> {
 	const pluginFolder = await getPluginFolder()
+	await installPreinstalledPlugins(pluginFolder)
 	const plugins = await getPluginList(pluginFolder, true)
 
 	const dockerCheck = await checkDocker()

--- a/src/main/schemas.ts
+++ b/src/main/schemas.ts
@@ -3,6 +3,7 @@ import { InferOutput, object, optional, safeParse, string } from 'valibot'
 export const PluginPackageJSONSchema = object({
 	name: string('Plugin name is required'),
 	pluginName: string('Readable plugin name is required'),
+	version: optional(string()),
 	icon: optional(string()),
 	index: string('Plugin index.html file is required'),
 	dockerCompose: optional(string())


### PR DESCRIPTION
## Summary

Finalizes Ouroboros production package bundle inputs.

- Renames package flavors to `core`, `with-plugins-cpu`, and `with-plugins-cuda`.
- Pins Neuroglancer to `v1.0.0` / `release.zip`.
- Pins automatic segmentation to `v0.4.0-beta` CPU/CUDA release assets.
- Records exact plugin release tags/artifacts and plugin release metadata in `package-flavor.json`.
- Updates production package flavor documentation.

Closes #93.

## Validation

- Fix-to-staging PR #94 passed.
- Staging smoke tag: `v1.4.0-packaging-smoke.6`
- Build and Release App run passed: https://github.com/ChengLabResearch/ouroboros/actions/runs/28620206040
- Publish Server Image run passed: https://github.com/ChengLabResearch/ouroboros/actions/runs/28620206592
