### PR TITLE
[codex] Fix SharedNPArray partial init cleanup

### DIFF
--- a/python/ouroboros/helpers/mem.py
+++ b/python/ouroboros/helpers/mem.py
@@ -21,6 +21,8 @@ def is_advanced_index(index):
 
 
 class SharedNPArray:
+    __shutdown = True
+
     def __init__(self, name: str, shape: DataShape, dtype: np.dtype,
                  views: list = None, *, allocate: bool = False):
         self.__name = name

--- a/python/test/helpers/test_mem.py
+++ b/python/test/helpers/test_mem.py
@@ -1,4 +1,5 @@
 from dataclasses import astuple
+import gc
 from multiprocessing.shared_memory import SharedMemory, ShareableList
 import pytest
 from sys import getsizeof
@@ -30,6 +31,18 @@ def test_alt_creation():
 
 def test_get_termed_mem_returns_global_list():
     assert get_termed_mem() is get_termed_mem()
+
+
+@pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
+def test_partial_shared_np_array_destruction_is_already_shutdown():
+    po = ProjOrder(Y=12, Theta=1501, X=2048)
+
+    partial = object.__new__(SharedNPArray)
+    partial.__del__()
+
+    with pytest.raises(FileNotFoundError):
+        SharedNPArray("MissingTestMem", po, np.uint16)
+    gc.collect()
 
 
 def test_direct_create():


### PR DESCRIPTION
Fixes #97

## Summary
- add a class-level `SharedNPArray.__shutdown` default of `True` so partially constructed instances are treated as already shut down
- add a regression test covering both `object.__new__` reconstruction and failed `SharedMemory` lookup without unraisable destructor warnings

## Root Cause
`SharedNPArray.__init__` could raise before assigning the instance `__shutdown` flag. When Python finalized that half-built object, `__del__` read the missing attribute and pytest reported a `PytestUnraisableExceptionWarning`.

## Validation
- `poetry run pytest test/helpers/test_mem.py -W error::pytest.PytestUnraisableExceptionWarning`
  - 5 passed in 2.38s
- `poetry run pytest`
  - 169 passed, 1 warning in 5.65s
  - the remaining warning is the separate Pydantic `model_fields` deprecation tracked by #98 / PR #100
