### PR TITLE
[codex] Fix Pydantic model_fields access

### DIFF
--- a/python/ouroboros/helpers/models.py
+++ b/python/ouroboros/helpers/models.py
@@ -114,5 +114,5 @@ def load_from_json(cls: type[BaseModel], json_path: str) -> BaseModel | str:
 
 
 def copy_values_from_other(self: BaseModel, other: BaseModel):
-    for field in self.model_fields.keys():
+    for field in type(self).model_fields.keys():
         setattr(self, field, getattr(other, field))

--- a/python/test/helpers/test_models.py
+++ b/python/test/helpers/test_models.py
@@ -1,4 +1,5 @@
 
+import pytest
 from pydantic import BaseModel
 from ouroboros.helpers.models import (
     model_with_json,
@@ -12,6 +13,7 @@ class SampleModel(BaseModel):
     field2: str
 
 
+@pytest.mark.filterwarnings("error::pydantic.PydanticDeprecatedSince211")
 def test_model_with_json(tmp_path):
     # Create an instance of SampleModel
     sample = SampleModel(field1=123, field2="test")


### PR DESCRIPTION
Fixes #98

## Summary
- switch `copy_values_from_other` to class-level Pydantic `model_fields` access through `type(self)`
- mark the existing copy-values coverage so `PydanticDeprecatedSince211` warnings fail that test path

## Root Cause
Pydantic 2.11 deprecated accessing `model_fields` on a model instance. The helper copied fields with `self.model_fields`, which still works today but warns and is scheduled for removal in Pydantic 3.0.

## Validation
- `poetry run pytest test/helpers/test_models.py -W error::pydantic.PydanticDeprecatedSince211`
  - 7 passed in 0.08s
- `rg "self\\.model_fields|self\\.model_fields_set|self\\.model_computed_fields" python/ouroboros`
  - no matches
- `poetry run pytest`
  - 168 passed, 1 warning in 7.75s
  - the remaining warning is the separate `SharedNPArray.__del__` unraisable warning tracked by #97 / PR #99
