### PR TITLE
[codex] Bound file explorer watcher

### DIFF
--- a/src/main/event-handlers/filesystem.ts
+++ b/src/main/event-handlers/filesystem.ts
@@ -1,10 +1,13 @@
 import { BrowserWindow, IpcMain } from 'electron'
 import { rename, rm, stat } from 'fs/promises'
-import { sep } from 'path'
+import { basename, join, relative, sep } from 'path'
 import Watcher from 'watcher'
 
 import { readFile, saveFile } from '../helpers'
-import { basename, join } from 'path'
+
+const FILE_EXPLORER_WATCH_DEPTH = 6
+const FILE_EXPLORER_WATCH_LIMIT = 100_000
+const IGNORED_PATH_SEGMENTS = new Set(['node_modules', '__pycache__', 'venv'])
 
 type FSEvent = {
 	event: string
@@ -19,8 +22,24 @@ type FSEvent = {
 	separator: string
 }
 
+type FSError = {
+	directoryPath: string
+	message: string
+	code?: string
+	depth: number
+	limit: number
+}
+
 export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => BrowserWindow): void => {
 	let subscription: Watcher | null = null
+
+	const sendFSError = (error: FSError): void => {
+		const mainWindow = getMainWindow?.()
+
+		if (mainWindow && !mainWindow.isDestroyed()) {
+			mainWindow.webContents.send('folder-contents-error', error)
+		}
+	}
 
 	// Fetch the contents of the given folder
 	ipcMain.handle('fetch-folder-contents', async (_, folderPath: string) => {
@@ -31,58 +50,124 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 			subscription = null
 		}
 
+		const shouldIgnorePath = (targetPath: string): boolean => {
+			const targetRelativePath = relative(folderPath, targetPath)
+
+			if (!targetRelativePath || targetRelativePath === '') return false
+			if (targetRelativePath.startsWith('..')) return false
+
+			const pathSegments = targetRelativePath.split(/[\\/]/)
+			return pathSegments.some((segment) => {
+				if (segment.startsWith('.')) return true
+				return IGNORED_PATH_SEGMENTS.has(segment)
+			})
+		}
+
+		let visibleAddCount = 0
+		let sentLimitWarning = false
+
+		const sendLimitWarning = (): void => {
+			if (sentLimitWarning) return
+
+			sentLimitWarning = true
+			sendFSError({
+				directoryPath: folderPath,
+				message: `File explorer stopped loading after ${FILE_EXPLORER_WATCH_LIMIT} visible paths. Choose a smaller folder or expand the folder in smaller pieces.`,
+				depth: FILE_EXPLORER_WATCH_DEPTH,
+				limit: FILE_EXPLORER_WATCH_LIMIT
+			})
+		}
+
 		// Send updates to the renderer when the folder contents change
-		subscription = new Watcher(folderPath, { recursive: true, renameDetection: true })
+		subscription = new Watcher(folderPath, {
+			recursive: true,
+			renameDetection: true,
+			depth: FILE_EXPLORER_WATCH_DEPTH,
+			limit: FILE_EXPLORER_WATCH_LIMIT,
+			ignore: shouldIgnorePath
+		})
+
+		subscription.on('error', (error) => {
+			sendFSError({
+				directoryPath: folderPath,
+				message: error instanceof Error ? error.message : 'Unknown file explorer watcher error',
+				code:
+					error instanceof Error && 'code' in error && typeof error.code === 'string'
+						? error.code
+						: undefined,
+				depth: FILE_EXPLORER_WATCH_DEPTH,
+				limit: FILE_EXPLORER_WATCH_LIMIT
+			})
+		})
 
 		subscription.on('all', async (event, targetPath, targetPathNext) => {
-			// eslint-disable-next-line no-useless-escape
-			if (/(^|\/)\.[^\/\.]/g.test(targetPath)) return
+			try {
+				if (shouldIgnorePath(targetPath)) return
 
-			let isDirectory = false
+				let isDirectory = false
 
-			const isRename = (event === 'rename' || event === 'renameDir') && targetPathNext
-			const isAddLike = event === 'add' || event === 'change' || event === 'addDir'
+				const isRename = (event === 'rename' || event === 'renameDir') && targetPathNext
+				const isAddLike = event === 'add' || event === 'change' || event === 'addDir'
 
-			// Check if the target path is a directory
-			if (isRename) {
-				const stats = await stat(targetPathNext)
-				isDirectory = stats.isDirectory()
-			} else if (isAddLike) {
-				const stats = await stat(targetPath)
-				isDirectory = stats.isDirectory()
-			}
+				// Check if the target path is a directory
+				if (isRename) {
+					const stats = await stat(targetPathNext)
+					isDirectory = stats.isDirectory()
+				} else if (isAddLike) {
+					const stats = await stat(targetPath)
+					isDirectory = stats.isDirectory()
+				}
 
-			// eslint-disable-next-line no-useless-escape
-			const relativePath = targetPath.replace(folderPath, '').replace(/^[\/\\]/, '')
+				if (event === 'add' || event === 'addDir') {
+					visibleAddCount++
+					if (visibleAddCount >= FILE_EXPLORER_WATCH_LIMIT) {
+						sendLimitWarning()
+					}
+				}
 
-			let relativePathNext = ''
-			if (targetPathNext) {
 				// eslint-disable-next-line no-useless-escape
-				relativePathNext = targetPathNext.replace(folderPath, '').replace(/^[\/\\]/, '')
-			}
+				const relativePath = targetPath.replace(folderPath, '').replace(/^[\/\\]/, '')
 
-			// Make sure the path is not the root folder
-			if (relativePath === '' || relativePath.length === 0) return
+				let relativePathNext = ''
+				if (targetPathNext) {
+					// eslint-disable-next-line no-useless-escape
+					relativePathNext = targetPathNext.replace(folderPath, '').replace(/^[\/\\]/, '')
+				}
 
-			// Split the path by the separator
-			const pathParts = relativePath.split(sep)
-			const nextPathParts = relativePathNext.split(sep)
+				// Make sure the path is not the root folder
+				if (relativePath === '' || relativePath.length === 0) return
 
-			const fsEvent: FSEvent = {
-				directoryPath: folderPath,
-				event,
-				targetPath,
-				targetPathNext,
-				isDirectory,
-				pathParts,
-				nextPathParts,
-				relativePath,
-				relativePathNext,
-				separator: sep
-			}
+				// Split the path by the separator
+				const pathParts = relativePath.split(sep)
+				const nextPathParts = relativePathNext.split(sep)
 
-			if (getMainWindow && getMainWindow()) {
-				getMainWindow().webContents.send('folder-contents-update', fsEvent)
+				const fsEvent: FSEvent = {
+					directoryPath: folderPath,
+					event,
+					targetPath,
+					targetPathNext: targetPathNext ?? '',
+					isDirectory,
+					pathParts,
+					nextPathParts,
+					relativePath,
+					relativePathNext,
+					separator: sep
+				}
+
+				if (getMainWindow && getMainWindow()) {
+					getMainWindow().webContents.send('folder-contents-update', fsEvent)
+				}
+			} catch (error) {
+				sendFSError({
+					directoryPath: folderPath,
+					message: error instanceof Error ? error.message : 'Unknown file explorer update error',
+					code:
+						error instanceof Error && 'code' in error && typeof error.code === 'string'
+							? error.code
+							: undefined,
+					depth: FILE_EXPLORER_WATCH_DEPTH,
+					limit: FILE_EXPLORER_WATCH_LIMIT
+				})
 			}
 		})
 	})

--- a/src/renderer/src/contexts/DirectoryContext.tsx
+++ b/src/renderer/src/contexts/DirectoryContext.tsx
@@ -1,5 +1,6 @@
 import { joinWithSeparator } from '@renderer/interfaces/file'
-import { JSX, createContext, useCallback, useEffect, useState } from 'react'
+import { AlertContext } from '@renderer/contexts/AlertContext'
+import { JSX, createContext, useCallback, useContext, useEffect, useState } from 'react'
 
 export type DirectoryContextValue = {
 	nodes: NodeChildren
@@ -23,6 +24,14 @@ type FSEvent = {
 	separator: string
 }
 
+type FSError = {
+	directoryPath: string
+	message: string
+	code?: string
+	depth: number
+	limit: number
+}
+
 export type FileSystemNode = {
 	name: string
 	path: string
@@ -37,6 +46,7 @@ function DirectoryProvider({ children }: { children: React.ReactNode }): JSX.Ele
 	const [directoryName, setDirectoryName] = useState<string | null>(null)
 	const [directoryPath, setDirectoryPath] = useState<string | null>(null)
 	const [nodes, setNodes] = useState<NodeChildren>({})
+	const { addAlert } = useContext(AlertContext)
 
 	const setDirectory = useCallback(
 		(directory: string): void => {
@@ -73,11 +83,20 @@ function DirectoryProvider({ children }: { children: React.ReactNode }): JSX.Ele
 			}
 		)
 
+		const clearFolderErrorListener = window.electron.ipcRenderer.on(
+			'folder-contents-error',
+			(_, fsError: FSError) => {
+				console.error('File explorer watcher error', fsError)
+				addAlert(fsError.message, 'warning')
+			}
+		)
+
 		return (): void => {
 			clearSelectedFolderListener()
 			clearFolderUpdateListener()
+			clearFolderErrorListener()
 		}
-	}, [])
+	}, [addAlert])
 
 	const refreshDirectory = useCallback(() => {
 		window.electron.ipcRenderer.invoke('fetch-folder-contents', directoryPath)

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -1,1 +1,15 @@
 /// <reference types="vite/client" />
+
+import type { JSX as ReactJSX } from 'react'
+
+declare global {
+	namespace JSX {
+		type Element = ReactJSX.Element
+		type ElementType = ReactJSX.ElementType
+		interface ElementClass extends ReactJSX.ElementClass {}
+		interface ElementAttributesProperty extends ReactJSX.ElementAttributesProperty {}
+		interface ElementChildrenAttribute extends ReactJSX.ElementChildrenAttribute {}
+		interface IntrinsicAttributes extends ReactJSX.IntrinsicAttributes {}
+		interface IntrinsicElements extends ReactJSX.IntrinsicElements {}
+	}
+}


### PR DESCRIPTION
Fixes #101
Part of #51

## Summary
- bound the recursive file explorer watcher with explicit depth and path-count limits
- ignore hidden paths plus dependency/cache folders before watcher traversal
- send watcher errors and limit warnings to the renderer as `folder-contents-error`
- show watcher warnings through the existing alert system
- add a React 19 JSX namespace compatibility declaration so `npm run typecheck` can validate the renderer

## Root Cause
The file explorer opened folders by starting an unbounded recursive watcher and mirroring every discovered path into renderer state. Very large folders can therefore consume large amounts of main-process watcher memory and renderer heap.

## Validation
- `npm run typecheck`
  - passed
