### PR TITLE
[codex] Batch file explorer updates

### DIFF
--- a/src/main/event-handlers/filesystem.ts
+++ b/src/main/event-handlers/filesystem.ts
@@ -7,6 +7,8 @@ import { readFile, saveFile } from '../helpers'
 
 const FILE_EXPLORER_WATCH_DEPTH = 6
 const FILE_EXPLORER_WATCH_LIMIT = 100_000
+const FILE_EXPLORER_UPDATE_BATCH_LIMIT = 500
+const FILE_EXPLORER_UPDATE_INTERVAL_MS = 100
 const IGNORED_PATH_SEGMENTS = new Set(['node_modules', '__pycache__', 'venv'])
 
 type FSEvent = {
@@ -32,6 +34,8 @@ type FSError = {
 
 export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => BrowserWindow): void => {
 	let subscription: Watcher | null = null
+	let pendingFSEvents: FSEvent[] = []
+	let pendingFSEventsTimeout: NodeJS.Timeout | null = null
 
 	const sendFSError = (error: FSError): void => {
 		const mainWindow = getMainWindow?.()
@@ -41,9 +45,53 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 		}
 	}
 
+	const flushPendingFSEvents = (): void => {
+		if (pendingFSEventsTimeout) {
+			clearTimeout(pendingFSEventsTimeout)
+			pendingFSEventsTimeout = null
+		}
+
+		if (pendingFSEvents.length === 0) return
+
+		const mainWindow = getMainWindow?.()
+		const batch = pendingFSEvents
+		pendingFSEvents = []
+
+		if (mainWindow && !mainWindow.isDestroyed()) {
+			mainWindow.webContents.send('folder-contents-update-batch', batch)
+		}
+	}
+
+	const clearPendingFSEvents = (): void => {
+		if (pendingFSEventsTimeout) {
+			clearTimeout(pendingFSEventsTimeout)
+			pendingFSEventsTimeout = null
+		}
+
+		pendingFSEvents = []
+	}
+
+	const queueFSEvent = (fsEvent: FSEvent): void => {
+		pendingFSEvents.push(fsEvent)
+
+		if (pendingFSEvents.length >= FILE_EXPLORER_UPDATE_BATCH_LIMIT) {
+			flushPendingFSEvents()
+			return
+		}
+
+		if (!pendingFSEventsTimeout) {
+			pendingFSEventsTimeout = setTimeout(
+				flushPendingFSEvents,
+				FILE_EXPLORER_UPDATE_INTERVAL_MS
+			)
+		}
+	}
+
 	// Fetch the contents of the given folder
 	ipcMain.handle('fetch-folder-contents', async (_, folderPath: string) => {
 		if (folderPath === '' || folderPath === undefined || folderPath === null) return
+
+		clearPendingFSEvents()
 
 		if (subscription) {
 			subscription.close()
@@ -154,9 +202,7 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 					separator: sep
 				}
 
-				if (getMainWindow && getMainWindow()) {
-					getMainWindow().webContents.send('folder-contents-update', fsEvent)
-				}
+				queueFSEvent(fsEvent)
 			} catch (error) {
 				sendFSError({
 					directoryPath: folderPath,

--- a/src/renderer/src/contexts/DirectoryContext.tsx
+++ b/src/renderer/src/contexts/DirectoryContext.tsx
@@ -83,6 +83,13 @@ function DirectoryProvider({ children }: { children: React.ReactNode }): JSX.Ele
 			}
 		)
 
+		const clearFolderUpdateBatchListener = window.electron.ipcRenderer.on(
+			'folder-contents-update-batch',
+			async (_, fsEvents: FSEvent[]) => {
+				setNodes((prev) => handleFSEvents(prev, fsEvents))
+			}
+		)
+
 		const clearFolderErrorListener = window.electron.ipcRenderer.on(
 			'folder-contents-error',
 			(_, fsError: FSError) => {
@@ -94,6 +101,7 @@ function DirectoryProvider({ children }: { children: React.ReactNode }): JSX.Ele
 		return (): void => {
 			clearSelectedFolderListener()
 			clearFolderUpdateListener()
+			clearFolderUpdateBatchListener()
 			clearFolderErrorListener()
 		}
 	}, [addAlert])
@@ -114,6 +122,10 @@ function DirectoryProvider({ children }: { children: React.ReactNode }): JSX.Ele
 }
 
 export default DirectoryProvider
+
+function handleFSEvents(nodes: NodeChildren, fsEvents: FSEvent[]): NodeChildren {
+	return fsEvents.reduce(handleFSEvent, nodes)
+}
 
 function handleFSEvent(nodes: NodeChildren, fsEvent: FSEvent): NodeChildren {
 	if (!fsEvent) return nodes


### PR DESCRIPTION
Fixes #103
Stacks on #104
Part of #51

## Summary
- queue file explorer watcher events in the main process
- flush queued events every 100 ms or every 500 events
- send batches through `folder-contents-update-batch`
- apply each batch in one renderer state update while keeping the old single-event listener

## Root Cause
Large initial folder scans could send one IPC message and one React state update per path. That amplified the memory and UI churn from recursive watching.

## Validation
- `npm run typecheck`
  - passed
