### PR TITLE
[codex] Limit plugin directory broadcasts

### DIFF
--- a/src/renderer/src/contexts/IFrameContext.tsx
+++ b/src/renderer/src/contexts/IFrameContext.tsx
@@ -47,8 +47,8 @@ export function IFrameProvider({ children }: { children: React.ReactNode }): JSX
 		'register-plugin': updateIframes
 	}
 
-	// Access the directory context
-	const data = useContext(DirectoryContext)
+	// Access the selected directory without broadcasting the full recursive file tree.
+	const { directoryPath, directoryName } = useContext(DirectoryContext)
 
 	const broadcast = useCallback(
 		(message: IFrameMessage): void => {
@@ -61,21 +61,22 @@ export function IFrameProvider({ children }: { children: React.ReactNode }): JSX
 		[iframes]
 	)
 
-	useEffect(() => {
-		if (!data) return
-
+	const broadcastDirectoryContext = useCallback((): void => {
 		const message: SendDirectoryContents = {
 			type: 'send-directory-contents',
 			data: {
-				directoryPath: data.directoryPath,
-				directoryName: data.directoryName,
-				nodes: data.nodes
+				directoryPath,
+				directoryName,
+				nodes: {}
 			}
 		}
 
-		// Send the directory info to the iframes
 		broadcast(message)
-	}, [data, broadcast])
+	}, [broadcast, directoryName, directoryPath])
+
+	useEffect(() => {
+		broadcastDirectoryContext()
+	}, [broadcastDirectoryContext])
 
 	useEffect(() => {
 		const listener = (event: MessageEvent): void => {


### PR DESCRIPTION
Refs #102
Stacks on #105
Part of #51

## Summary
- stop broadcasting the full recursive `nodes` tree to plugin iframes on every directory state update
- continue broadcasting selected directory path/name metadata through the existing message type
- keep `nodes` in the payload as an empty object for shape compatibility while the fuller on-demand plugin API is designed

## Root Cause
The iframe provider cloned and posted the full file explorer tree whenever directory context changed. For large folders this created another memory multiplier on top of watcher and renderer state.

## Validation
- `npm run typecheck`
  - passed

## Follow-Up
This is a first slice of #102. Lazy-loading the file explorer tree and adding an explicit plugin request API are still tracked there.
