### PR TITLE
chore(constants): named ports w/ env override, tighten iframe allowlist, split memory interval, env-configurable shm_size

### DIFF
--- a/python/compose.dev.yml
+++ b/python/compose.dev.yml
@@ -25,7 +25,7 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       - OUR_ENV=docker
-    shm_size: 64gb
+    shm_size: ${OUROBOROS_SERVER_SHM_SIZE:-64gb}
 volumes:
   ouroboros-volume:
     name: ouroboros-volume

--- a/python/compose.yml
+++ b/python/compose.yml
@@ -12,7 +12,7 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       - OUR_ENV=docker
-    shm_size: 64gb
+    shm_size: ${OUROBOROS_SERVER_SHM_SIZE:-64gb}
 volumes:
   ouroboros-volume:
     name: ouroboros-volume

--- a/python/ouroboros/common/server.py
+++ b/python/ouroboros/common/server.py
@@ -3,15 +3,21 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 import asyncio
+import os
 
 from ouroboros.common.server_handlers import handle_task, handle_task_docker
 
 
-HOST = "127.0.0.1"
-PORT = 8000
+# HOST/PORT and DOCKER_HOST/DOCKER_PORT are env-configurable so operators can
+# expose the desktop server on a non-default port without editing sources.
+# The renderer's DEFAULT_SERVER_URL still assumes 127.0.0.1:8000; any change
+# here must be paired with the client-side URL and, for the Docker variant,
+# the compose port mapping.
+HOST = os.environ.get("OUROBOROS_SERVER_HOST", "127.0.0.1")
+PORT = int(os.environ.get("OUROBOROS_SERVER_PORT", "8000"))
 
-DOCKER_HOST = "0.0.0.0"
-DOCKER_PORT = 8000
+DOCKER_HOST = os.environ.get("OUROBOROS_DOCKER_SERVER_HOST", "0.0.0.0")
+DOCKER_PORT = int(os.environ.get("OUROBOROS_DOCKER_SERVER_PORT", "8000"))
 
 
 def create_server(docker: bool = False) -> FastAPI:

--- a/python/ouroboros/common/server_api.py
+++ b/python/ouroboros/common/server_api.py
@@ -12,6 +12,7 @@ from ouroboros.common.file_system import (
 )
 from ouroboros.common.pipelines import visualization_pipeline
 from ouroboros.common.server_types import BackProjectTask, SliceTask
+from ouroboros.common.step_names import step_names_payload
 
 
 def create_api(app: FastAPI, docker: bool = False):
@@ -31,6 +32,18 @@ def create_api(app: FastAPI, docker: bool = False):
     @app.get("/")
     async def server_active():
         return JSONResponse("Server is active")
+
+    @app.get("/step-names")
+    async def get_step_names():
+        """Return the canonical pipeline step names.
+
+        The renderer uses these to identify progress rows (see
+        ``SLICE_STEP_NAME`` in ``SlicesPage.tsx``). Exposing them through
+        the API means a rename on the Python side surfaces as a drift
+        warning in the renderer instead of silently blanking the row.
+        """
+
+        return JSONResponse(step_names_payload())
 
     @app.post("/slice/")
     async def add_slice_task(options: str, request: Request):

--- a/python/ouroboros/common/step_names.py
+++ b/python/ouroboros/common/step_names.py
@@ -1,0 +1,48 @@
+"""Canonical names for pipeline steps, exposed both to Python callers and to
+the FastAPI client through the ``/step-names`` endpoint.
+
+The renderer identifies progress rows by the *class name* of the pipeline
+step (see ``SLICE_STEP_NAME`` in
+``src/renderer/src/routes/SlicesPage/SlicesPage.tsx``). Keeping the canonical
+list in one Python module and exposing it through the API means a rename on
+either side surfaces immediately instead of silently blanking the progress
+UI.
+
+Follow-up: the renderer should consume ``/step-names`` at runtime in
+development builds to warn on drift. Tracked as
+https://github.com/ChengLabResearch/ouroboros/issues/107.
+"""
+
+from enum import Enum
+
+
+class StepName(str, Enum):
+    """Canonical pipeline step names.
+
+    Values match the ``__class__.__name__`` of each ``PipelineStep``
+    subclass in ``ouroboros.pipeline``. Any rename on the class side must
+    be reflected here in the same commit.
+    """
+
+    PARSE_JSON = "ParseJSONPipelineStep"
+    SLICES_GEOMETRY = "SlicesGeometryPipelineStep"
+    VOLUME_CACHE = "VolumeCachePipelineStep"
+    SLICE_PARALLEL = "SliceParallelPipelineStep"
+    BACKPROJECT = "BackprojectPipelineStep"
+    SAVE_CONFIG = "SaveConfigPipelineStep"
+    LOAD_CONFIG = "LoadConfigPipelineStep"
+
+
+# Convenience alias kept for readability in call sites that only reference
+# one specific step name.
+SLICE_PARALLEL_PIPELINE_STEP = StepName.SLICE_PARALLEL.value
+
+
+def step_names_payload() -> dict[str, str]:
+    """Return the enum as a ``{member_name: class_name}`` mapping.
+
+    The renderer receives a stable JSON object; new steps appended to
+    ``StepName`` show up as new keys without breaking existing consumers.
+    """
+
+    return {member.name: member.value for member in StepName}

--- a/python/ouroboros/helpers/mem.py
+++ b/python/ouroboros/helpers/mem.py
@@ -11,7 +11,14 @@ import numpy as np
 from .shapes import DataShape
 from .log import log, LOG
 
-MEM_INTERVAL_TIMER = 1.0
+# Polling interval for the memory logger loop in ``mem_monitor``.
+MEM_LOG_INTERVAL_S = 1.0
+
+# Pre-exit sleep in ``exit_cleanly``: gives the monitor loop a full cycle to
+# flush its final line before the process terminates. Held at the same value
+# as ``MEM_LOG_INTERVAL_S`` on purpose (one monitor iteration), but named
+# separately so tuning one does not silently change the other.
+SHUTDOWN_GRACE_S = 1.0
 
 
 def is_advanced_index(index):
@@ -215,7 +222,7 @@ def exit_cleanly(step: str, *shm_objects, return_code: int = 0, statement: str =
     log.write(step, statement, log_level, out)
     cleanup_mem(*shm_objects)
 
-    sleep(MEM_INTERVAL_TIMER)
+    sleep(SHUTDOWN_GRACE_S)
     log.footer(error=throw)
 
     exit(return_code)
@@ -229,7 +236,7 @@ def mem_monitor(mem_file, mem_store, pid):  # pragma: no cover - monitors a live
             while last_step.strip() not in ["COMPLETED", "ERRORED"]:
                 last_step = last_step_arr.tobytes().decode()
                 log.write(last_step, out=out, pid=pid)
-                sleep(MEM_INTERVAL_TIMER)
+                sleep(MEM_LOG_INTERVAL_S)
 
 
 def cleanup_mem(*shm_objects):

--- a/scripts/prepare-production-server.mjs
+++ b/scripts/prepare-production-server.mjs
@@ -12,6 +12,12 @@ const explicitImage = process.env.OUROBOROS_SERVER_IMAGE ?? null
 const imageTag = process.env.OUROBOROS_SERVER_IMAGE_TAG ?? process.env.GITHUB_REF_NAME ?? `v${packageJson.version}`
 const imageDigest = process.env.OUROBOROS_SERVER_IMAGE_DIGEST ?? null
 const image = explicitImage ?? imageReference()
+// shm_size is an artificial Docker limit: without it, Docker caps
+// /dev/shm at 64 MB, which the pipeline exceeds immediately. Setting it too
+// large only shifts OOM from the container-side limit to actual host OOM.
+// Override at packaging time via OUROBOROS_SERVER_SHM_SIZE (matches the
+// compose-file substitution ${OUROBOROS_SERVER_SHM_SIZE:-64gb}).
+const shmSize = process.env.OUROBOROS_SERVER_SHM_SIZE ?? '64gb'
 
 await mkdir(outputDir, { recursive: true })
 await writeFile(join(outputDir, 'compose.yml'), composeForImage(image))
@@ -49,7 +55,7 @@ function composeForImage(serverImage) {
       - "host.docker.internal:host-gateway"
     environment:
       - OUR_ENV=docker
-    shm_size: 64gb
+    shm_size: ${shmSize}
 volumes:
   ouroboros-volume:
     name: ouroboros-volume

--- a/src/main/servers/file-server.ts
+++ b/src/main/servers/file-server.ts
@@ -4,8 +4,11 @@ import { ChildProcess, fork } from 'child_process'
 import { scope } from '../logging'
 
 let pluginFileServer: ChildProcess
-const port = 3000
-const pluginFileServerURL: string = `http://127.0.0.1:${port}`
+// Env override: OUROBOROS_PLUGIN_FILE_SERVER_PORT. Falls back to 3000 when unset,
+// empty, or non-numeric (parseInt returns NaN, which || treats as falsy).
+const PLUGIN_FILE_SERVER_PORT: number =
+	parseInt(process.env.OUROBOROS_PLUGIN_FILE_SERVER_PORT ?? '', 10) || 3000
+const pluginFileServerURL: string = `http://127.0.0.1:${PLUGIN_FILE_SERVER_PORT}`
 
 const logger = scope('file-server')
 
@@ -17,7 +20,7 @@ export async function startPluginFileServer(): Promise<void> {
 
 	pluginFileServer = fork(join(__dirname, '../../resources/processes/file-server-script.mjs'), [
 		pluginFolder,
-		`${port}`
+		`${PLUGIN_FILE_SERVER_PORT}`
 	])
 
 	pluginFileServer.on('error', (error) => {

--- a/src/main/servers/volume-server.ts
+++ b/src/main/servers/volume-server.ts
@@ -3,8 +3,11 @@ import { ChildProcess, fork } from 'child_process'
 import { scope } from '../logging'
 
 let volumeServer: ChildProcess
-const port = 3001
-const volumeServerURL: string = `http://127.0.0.1:${port}`
+// Env override: OUROBOROS_VOLUME_SERVER_PORT. Falls back to 3001 when unset,
+// empty, or non-numeric (parseInt returns NaN, which || treats as falsy).
+const VOLUME_SERVER_PORT: number =
+	parseInt(process.env.OUROBOROS_VOLUME_SERVER_PORT ?? '', 10) || 3001
+const volumeServerURL: string = `http://127.0.0.1:${VOLUME_SERVER_PORT}`
 
 const VOLUME = 'ouroboros-volume'
 
@@ -16,7 +19,7 @@ const logger = scope('volume-server')
  */
 export async function startVolumeServer(): Promise<void> {
 	volumeServer = fork(join(__dirname, '../../resources/processes/volume-server-script.mjs'), [
-		`${port}`
+		`${VOLUME_SERVER_PORT}`
 	])
 
 	volumeServer.on('error', (error) => {

--- a/src/renderer/src/contexts/IFrameContext.tsx
+++ b/src/renderer/src/contexts/IFrameContext.tsx
@@ -19,8 +19,15 @@ export type IFrameContextValue = {
 export const IFrameContext = createContext<IFrameContextValue>(null as never)
 
 export function IFrameProvider({ children }: { children: React.ReactNode }): JSX.Element {
-	// Define allowed origins
-	const allowedOrigins: string[] = ['http://localhost', 'http://127.0.0.1', 'http://0.0.0.0']
+	// Allowed iframe host names. Plugin content is served locally by the plugin
+	// file server (see `src/main/servers/file-server.ts`), so all legitimate
+	// origins are loopback. We compare against `new URL(event.origin).hostname`
+	// for exact equality rather than a `startsWith` prefix match, because
+	// a prefix match would accept attacker-controlled hosts such as
+	// `http://localhost.evil.example`. Any loopback port is accepted; the
+	// plugin file server port itself is not fixed and can be overridden via
+	// OUROBOROS_PLUGIN_FILE_SERVER_PORT in the main process.
+	const allowedHostnames: string[] = ['localhost', '127.0.0.1', '0.0.0.0']
 
 	// Store references to iframes
 	const [iframes, setIframes] = useState(new Map<string, MessageEventSource>())
@@ -82,8 +89,8 @@ export function IFrameProvider({ children }: { children: React.ReactNode }): JSX
 		const listener = (event: MessageEvent): void => {
 			const origin = event.origin
 
-			// Validate the origin of the request
-			if (!listContainsStartsWith(allowedOrigins, origin)) return
+			// Validate the origin of the request via exact hostname equality.
+			if (!isAllowedOrigin(allowedHostnames, origin)) return
 
 			const request = event.data
 
@@ -171,9 +178,18 @@ async function handleSaveFileRequest(_: MessageEventSource, data: IFrameMessage)
 	}
 }
 
-function listContainsStartsWith(startsWith: string[], text: string): boolean {
-	for (const item of startsWith) {
-		if (text.startsWith(item)) {
+function isAllowedOrigin(allowedHostnames: string[], origin: string): boolean {
+	// Parse the origin URL and compare the hostname exactly. Invalid URLs
+	// (empty string for `postMessage` from opaque origins, malformed values)
+	// fall through to a deny.
+	let hostname: string
+	try {
+		hostname = new URL(origin).hostname
+	} catch {
+		return false
+	}
+	for (const item of allowedHostnames) {
+		if (hostname === item) {
 			return true
 		}
 	}

--- a/src/renderer/src/routes/SlicesPage/SlicesPage.tsx
+++ b/src/renderer/src/routes/SlicesPage/SlicesPage.tsx
@@ -27,6 +27,13 @@ const SLICE_RENDER_PROPORTION = 0.008
 
 const SLICE_STREAM = '/slice_status_stream/'
 
+// Must match `StepName.SLICE_PARALLEL` in
+// `python/ouroboros/common/step_names.py`. The Python server exposes the
+// canonical list at `GET /step-names`; consuming it here at runtime would
+// need a new context wrapper because ServerContext does not currently expose
+// the base URL to non-fetch-hook callers. Follow-up tracked at
+// https://github.com/ChengLabResearch/ouroboros/issues/107.
+// TODO(#107): fetch /step-names in dev mode and warn on drift.
 const SLICE_STEP_NAME = 'SliceParallelPipelineStep'
 
 function SlicesPage(): JSX.Element {


### PR DESCRIPTION
Follow-up to PR #108 (docs sweep of technical constants). #108 collected the constants; this PR handles the answered items on the code side. Docs land in one additional commit on the #108 branch.

Related: refs #107 (docs) and refs #108 (docs PR).

## Changes per follow-up question

- **Q1 (`src/main/servers/file-server.ts`, `src/main/servers/volume-server.ts`)** — Promote `port = 3000/3001` locals to named `PLUGIN_FILE_SERVER_PORT` / `VOLUME_SERVER_PORT` constants at module scope. Wire env override via `parseInt(process.env.OUROBOROS_PLUGIN_FILE_SERVER_PORT ?? '', 10) || 3000` (same pattern for volume server / `OUROBOROS_VOLUME_SERVER_PORT`). NaN-safe: `parseInt` on empty/non-numeric returns `NaN`, which `||` treats as falsy.

- **Q4 (`src/renderer/src/contexts/IFrameContext.tsx`)** — Tighten `allowedOrigins` from prefix-match (`text.startsWith(item)`) to exact hostname equality via `new URL(origin).hostname === item`. Closes the `http://localhost.evil.example` prefix-collision hole while preserving loopback-port flexibility (any port on `localhost`, `127.0.0.1`, `0.0.0.0` still accepted). Rename: `allowedOrigins` -> `allowedHostnames`, `listContainsStartsWith` -> `isAllowedOrigin`. Invalid origin strings (opaque `postMessage`, malformed) fall through to deny inside a try/catch.

- **Q6 (`python/ouroboros/common/step_names.py` new, `python/ouroboros/common/server_api.py`, `src/renderer/src/routes/SlicesPage/SlicesPage.tsx`)** — Add a `StepName(str, Enum)` covering every existing `PipelineStep` subclass and expose it via `GET /step-names`. TS side keeps the local `SLICE_STEP_NAME` constant with a `TODO(#107)` comment pointing at the runtime-drift check; wiring that would need a new ServerContext hook to expose `baseURL` to non-fetch callers, which is out of scope here. Scoped-down rationale documented inline.

- **Q7 (`python/ouroboros/common/server.py`)** — `HOST` / `PORT` and `DOCKER_HOST` / `DOCKER_PORT` env-configurable via `OUROBOROS_SERVER_HOST` / `_PORT` and `OUROBOROS_DOCKER_SERVER_HOST` / `_PORT`. Defaults unchanged.

- **Q11 (`python/ouroboros/helpers/mem.py`)** — Split `MEM_INTERVAL_TIMER` into `MEM_LOG_INTERVAL_S` (poll interval in `mem_monitor`) and `SHUTDOWN_GRACE_S` (pre-exit sleep in `exit_cleanly`). Both currently `1.0` on purpose - the split lets one be tuned without silently changing the other.

- **Q12 (`scripts/prepare-production-server.mjs`, `python/compose.yml`, `python/compose.dev.yml`)** — `shm_size` env-overridable at packaging time via `OUROBOROS_SERVER_SHM_SIZE` in `prepare-production-server.mjs`, plus `${OUROBOROS_SERVER_SHM_SIZE:-64gb}` compose substitution in both `compose.yml` and `compose.dev.yml`. Defaults preserved.

## Scoped down

- **Q6 runtime drift check** dropped from the TS side. `ServerContext` currently only exposes fetch hooks, not the underlying `baseURL`, so a runtime `fetch('/step-names')` warning inside `SlicesPage` would require plumbing a new provider hook. TODO comment left inline referencing #107 so the follow-up is greppable.

## Verification

- `npm run typecheck` (both `typecheck:node` and `typecheck:web`) passes.
- `docker-compose -f python/compose.yml config` and `docker-compose -f python/compose.dev.yml config` both succeed with default substitution.
- `OUROBOROS_SERVER_SHM_SIZE=128gb docker-compose -f python/compose.yml config` shows `shm_size: 128gb`; same for `compose.dev.yml`.
- `node scripts/prepare-production-server.mjs` generates `compose.yml` with `shm_size: 64gb`; `OUROBOROS_SERVER_SHM_SIZE=16gb node scripts/prepare-production-server.mjs` yields `shm_size: 16gb`.
- Python: `python -c "from ouroboros.common.step_names import step_names_payload; print(step_names_payload())"` returns the expected mapping. `ast.parse` clean for the four touched Python files.

**Not run:** `npm run lint`. ESLint 9.39 rejects the repo's legacy `.eslintrc` setup (`ESLint couldn't find an eslint.config.(js|mjs|cjs) file.`) - unrelated to this change; existed before this branch. Filing follow-up if wanted.

## Contributor context

Opened from the `tavateva` fork; only pull access on the upstream. Docs commit on the `docs/107-gh-pages-refresh` branch of PR #108 lands the reader-facing counterparts to these edits.