### PR TITLE
feat(file-explorer): lazy per-directory watchers + deferred teardown

### DIFF
--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -31,15 +31,23 @@ _It is recommended that you read these pages in order._
 ## Large Folder Behavior
 
 The Ouroboros File Explorer is designed to open scan and output folders
-directly, but it is not a general-purpose file browser. When you point it
-at a folder that contains many files or deeply nested subfolders, the
-following limits apply:
+directly, but it is not a general-purpose file browser. It loads
+subfolders on demand: opening a folder shows only that folder's direct
+entries, and subfolder contents stream in when you expand each subfolder.
+When you point it at a folder that contains many files or deeply nested
+subfolders, the following behavior applies:
 
-- Only the first six directory levels below the folder you open are
-  walked.
+- Only the root's direct entries are loaded up front. Nested subfolders
+  are loaded and watched only when you expand them.
+- Collapsing a subfolder keeps its state and watcher alive for a short
+  window (thirty seconds by default) so quickly re-expanding is free. If
+  you leave it collapsed past that window, the underlying watcher is torn
+  down and the subfolder's cached children are dropped from renderer
+  state; re-expanding later behaves like a fresh load.
 - The panel stops loading new paths after one hundred thousand visible
-  entries. When this happens, Ouroboros shows a warning toast asking you
-  to pick a smaller folder or expand the folder in smaller pieces.
+  entries across all currently open watchers. When this happens,
+  Ouroboros shows a warning toast asking you to pick a smaller folder or
+  expand the folder in smaller pieces.
 - `node_modules`, `__pycache__`, `venv`, and any directory whose name
   starts with `.` are always skipped.
 

--- a/documentation/docs/reference/technical-constants.md
+++ b/documentation/docs/reference/technical-constants.md
@@ -8,59 +8,78 @@ source. If you change them locally, update this page in the same commit.
 
 All file explorer limits live in
 [`src/main/event-handlers/filesystem.ts`][filesystem-ts] at the top of the
-file. They apply to the recursive watcher that backs the File Explorer
-panel in the Electron app.
+file, alongside the shared teardown delay in
+[`src/shared/constants.ts`][shared-constants-ts]. They apply to the
+per-directory non-recursive watchers with lazy expansion that back the
+File Explorer panel in the Electron app.
 
-### Watcher depth limit
-
-- Symbol: `FILE_EXPLORER_WATCH_DEPTH`
-- Value: `6`
-- Source: [`src/main/event-handlers/filesystem.ts`][filesystem-ts] line 8
-- Also passed to the underlying `watcher` package as its `depth` option and
-  reported inside every `folder-contents-error` payload.
-
-**Why it exists.** The file explorer used to open folders with an
-unbounded recursive watcher. Deep dependency trees, build outputs, or
-scientific datasets could push watcher and renderer state well past the
-V8 heap and trigger the crash described in [#51][issue-51].
-
-**User-visible behavior when reached.** Directories nested more than six
-levels below the selected root are simply not walked, so their contents do
-not appear in the File Explorer panel. The panel still works normally at
-shallower depths.
-
-**When to reconsider.** Raise this if you routinely need to see files
-deeper than six levels from the folder you open in Ouroboros and you have
-already excluded large auxiliary trees (see the ignored segments below).
-Prefer opening a lower-level folder before increasing the constant.
+Starting with [#110][pr-110], the file explorer no longer opens a single
+recursive watcher on the selected root. Instead, the main process keeps
+one non-recursive watcher per directory the user has currently expanded,
+plus one for the root. Expanding a subfolder starts a new watcher for it;
+collapsing schedules teardown after
+[`COLLAPSE_TEARDOWN_DELAY_MS`](#watcher-teardown-delay-after-collapse),
+so quick collapse-then-reopen costs nothing.
 
 ### Watcher path-count limit
 
 - Symbol: `FILE_EXPLORER_WATCH_LIMIT`
 - Value: `100_000`
 - Source: [`src/main/event-handlers/filesystem.ts`][filesystem-ts] line 9
-- Passed to the underlying `watcher` package as its `limit` option and
-  reported inside every `folder-contents-error` payload.
+- Reported inside every `folder-contents-error` payload.
 
-**Why it exists.** The watcher mirrors every discovered path into
-renderer state. Very large folders can therefore multiply main-process
-watcher memory with renderer heap. One hundred thousand visible paths is
-the ceiling picked in [#104][pr-104] as a balance between usefulness for
-typical scan/output folders and keeping the renderer well under its
-default 4 GB heap.
+**Why it exists.** Every watcher mirrors its discovered paths into
+renderer state. Even with lazy expansion, an aggressive user could open a
+handful of dense subfolders in sequence and still exhaust memory. One
+hundred thousand visible paths is the ceiling picked in [#104][pr-104] as
+a balance between usefulness for typical scan/output folders and keeping
+the renderer well under its default 4 GB heap.
 
-**User-visible behavior when reached.** Once the visible add count crosses
-the limit, the main process emits `folder-contents-error` with a message
-of the form `File explorer stopped loading after 100000 visible paths.
-Choose a smaller folder or expand the folder in smaller pieces.` The
-existing renderer alert system surfaces this as a warning toast. The
-watcher stops delivering further add events for that session; already
-loaded paths remain visible.
+**Role change from #110.** Before #110 this was the underlying `watcher`
+package's per-watcher `limit`. Under the lazy model it is instead an
+aggregate session budget summed across every currently open watcher; a
+watcher's contribution is reclaimed when its folder is collapsed and torn
+down.
+
+**User-visible behavior when reached.** Once the aggregate visible add
+count crosses the limit, the main process emits `folder-contents-error`
+with a message of the form `File explorer stopped loading after 100000
+visible paths across all open folders. Choose a smaller folder or expand
+the folder in smaller pieces.` The existing renderer alert system
+surfaces this as a warning toast. Further add events for that session are
+not attributed to the counter but already loaded paths remain visible.
 
 **When to reconsider.** Raise this only after profiling shows headroom in
-both the main watcher and the renderer heap for your typical workload.
+both the main watchers and the renderer heap for your typical workload.
 Lower it if you routinely work on constrained machines and want the
 warning to appear sooner.
+
+### Watcher teardown delay after collapse
+
+- Symbol: `COLLAPSE_TEARDOWN_DELAY_MS`
+- Value: `30_000` (milliseconds)
+- Source: [`src/shared/constants.ts`][shared-constants-ts]
+
+**Why it exists.** Collapsing a folder in the file explorer should not
+immediately close its watcher and drop its renderer state, because users
+routinely collapse-then-reopen the same folder while navigating. The
+delay makes that pattern free: as long as the user re-expands within
+thirty seconds, no watcher churn and no state re-fetch happen. After the
+delay elapses, the main process closes the non-recursive watcher on the
+collapsed subfolder and the renderer prunes its children from state.
+Root's watcher is exempt - collapsing root is a no-op; root's watcher
+only closes when a new root is opened or the window is torn down.
+
+**User-visible behavior when reached.** Nothing visible changes at the
+moment of teardown. The collapsed folder's shell remains rendered; its
+children have already stopped rendering visually because of the collapse.
+Re-expanding after teardown behaves like a fresh expand: the main process
+starts a new watcher and streams the initial batch back into the
+renderer's state.
+
+**When to reconsider.** Shorten if renderer memory pressure from
+still-cached collapsed subtrees is a problem. Lengthen if users complain
+that re-opening a folder after a long detour repopulates it visibly.
 
 ### Update batch size
 
@@ -519,12 +538,17 @@ filename together, since the artifact filename embeds the tag.
 ## Where the values come from
 
 Every value above was read directly from the tree at the time this page
-was written. The five file explorer constants live together as a block at
-the top of [`src/main/event-handlers/filesystem.ts`][filesystem-ts]
-(lines 8-12). If you edit any of them, update this page in the same
-commit so operators and plugin authors can rely on it.
+was written. The remaining file explorer constants live together as a
+block at the top of
+[`src/main/event-handlers/filesystem.ts`][filesystem-ts]; the shared
+teardown delay lives in [`src/shared/constants.ts`][shared-constants-ts]
+so both the main process and the renderer import the same value. If you
+edit any of them, update this page in the same commit so operators and
+plugin authors can rely on it.
 
 [filesystem-ts]: https://github.com/ChengLabResearch/ouroboros/blob/main/src/main/event-handlers/filesystem.ts
+[shared-constants-ts]: https://github.com/ChengLabResearch/ouroboros/blob/main/src/shared/constants.ts
+[pr-110]: https://github.com/ChengLabResearch/ouroboros/pull/110
 [iframe-context]: https://github.com/ChengLabResearch/ouroboros/blob/main/src/renderer/src/contexts/IFrameContext.tsx
 [file-server-ts]: https://github.com/ChengLabResearch/ouroboros/blob/main/src/main/servers/file-server.ts
 [file-server-script]: https://github.com/ChengLabResearch/ouroboros/blob/main/resources/processes/file-server-script.mjs

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -18,7 +18,8 @@ export default defineConfig({
 	renderer: {
 		resolve: {
 			alias: {
-				'@renderer': resolve('src/renderer/src')
+				'@renderer': resolve('src/renderer/src'),
+				'@shared': resolve('src/shared')
 			}
 		},
 		plugins: [

--- a/src/main/event-handlers/filesystem.ts
+++ b/src/main/event-handlers/filesystem.ts
@@ -4,8 +4,8 @@ import { basename, join, relative, sep } from 'path'
 import Watcher from 'watcher'
 
 import { readFile, saveFile } from '../helpers'
+import { COLLAPSE_TEARDOWN_DELAY_MS } from '../../shared/constants'
 
-const FILE_EXPLORER_WATCH_DEPTH = 6
 const FILE_EXPLORER_WATCH_LIMIT = 100_000
 const FILE_EXPLORER_UPDATE_BATCH_LIMIT = 500
 const FILE_EXPLORER_UPDATE_INTERVAL_MS = 100
@@ -28,12 +28,29 @@ type FSError = {
 	directoryPath: string
 	message: string
 	code?: string
-	depth: number
 	limit: number
 }
 
+type WatcherEntry = {
+	watcher: Watcher
+	addCount: number
+	pendingTeardownTimer: NodeJS.Timeout | null
+}
+
 export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => BrowserWindow): void => {
-	let subscription: Watcher | null = null
+	// One non-recursive watcher per currently expanded directory. The root
+	// watcher lives here too - root is just a distinguished expanded folder.
+	const watchers = new Map<string, WatcherEntry>()
+
+	// Aggregate visible-add count across every open watcher in this session.
+	// `FILE_EXPLORER_WATCH_LIMIT` is a session budget, not a per-watcher one.
+	let visibleAddCount = 0
+	let sentLimitWarning = false
+
+	// The currently open root. `collapse-folder(root)` is a no-op so we can
+	// guard against nonsensical collapse-of-root requests.
+	let currentRoot: string | null = null
+
 	let pendingFSEvents: FSEvent[] = []
 	let pendingFSEventsTimeout: NodeJS.Timeout | null = null
 
@@ -87,19 +104,57 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 		}
 	}
 
-	// Fetch the contents of the given folder
-	ipcMain.handle('fetch-folder-contents', async (_, folderPath: string) => {
-		if (folderPath === '' || folderPath === undefined || folderPath === null) return
+	const sendLimitWarning = (folderPath: string): void => {
+		if (sentLimitWarning) return
 
-		clearPendingFSEvents()
+		sentLimitWarning = true
+		sendFSError({
+			directoryPath: folderPath,
+			message: `File explorer stopped loading after ${FILE_EXPLORER_WATCH_LIMIT} visible paths across all open folders. Choose a smaller folder or expand the folder in smaller pieces.`,
+			limit: FILE_EXPLORER_WATCH_LIMIT
+		})
+	}
 
-		if (subscription) {
-			subscription.close()
-			subscription = null
+	// Close every open watcher and reset all associated state. Used when the
+	// root changes and on window teardown / app quit.
+	const closeAllWatchers = (): void => {
+		for (const entry of watchers.values()) {
+			if (entry.pendingTeardownTimer) {
+				clearTimeout(entry.pendingTeardownTimer)
+				entry.pendingTeardownTimer = null
+			}
+			entry.watcher.close()
+		}
+		watchers.clear()
+		visibleAddCount = 0
+		sentLimitWarning = false
+	}
+
+	// Tear down a single watcher entry and reclaim its contribution to the
+	// aggregate visible-add counter.
+	const teardownWatcher = (subPath: string): void => {
+		const entry = watchers.get(subPath)
+		if (!entry) return
+
+		if (entry.pendingTeardownTimer) {
+			clearTimeout(entry.pendingTeardownTimer)
+			entry.pendingTeardownTimer = null
 		}
 
+		entry.watcher.close()
+		visibleAddCount = Math.max(0, visibleAddCount - entry.addCount)
+		watchers.delete(subPath)
+	}
+
+	// Start a non-recursive watcher on `subPath`. `rootPath` is the root the
+	// renderer treats as the top of its tree; every batched event's relative
+	// path is computed against it so the renderer's nested `nodes` map lines
+	// up regardless of which folder produced the event.
+	const startWatcher = (rootPath: string, subPath: string): void => {
+		if (watchers.has(subPath)) return
+
 		const shouldIgnorePath = (targetPath: string): boolean => {
-			const targetRelativePath = relative(folderPath, targetPath)
+			const targetRelativePath = relative(rootPath, targetPath)
 
 			if (!targetRelativePath || targetRelativePath === '') return false
 			if (targetRelativePath.startsWith('..')) return false
@@ -111,44 +166,32 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 			})
 		}
 
-		let visibleAddCount = 0
-		let sentLimitWarning = false
-
-		const sendLimitWarning = (): void => {
-			if (sentLimitWarning) return
-
-			sentLimitWarning = true
-			sendFSError({
-				directoryPath: folderPath,
-				message: `File explorer stopped loading after ${FILE_EXPLORER_WATCH_LIMIT} visible paths. Choose a smaller folder or expand the folder in smaller pieces.`,
-				depth: FILE_EXPLORER_WATCH_DEPTH,
-				limit: FILE_EXPLORER_WATCH_LIMIT
-			})
-		}
-
-		// Send updates to the renderer when the folder contents change
-		subscription = new Watcher(folderPath, {
-			recursive: true,
+		const watcher = new Watcher(subPath, {
+			recursive: false,
 			renameDetection: true,
-			depth: FILE_EXPLORER_WATCH_DEPTH,
-			limit: FILE_EXPLORER_WATCH_LIMIT,
 			ignore: shouldIgnorePath
 		})
 
-		subscription.on('error', (error) => {
+		const entry: WatcherEntry = {
+			watcher,
+			addCount: 0,
+			pendingTeardownTimer: null
+		}
+		watchers.set(subPath, entry)
+
+		watcher.on('error', (error) => {
 			sendFSError({
-				directoryPath: folderPath,
+				directoryPath: subPath,
 				message: error instanceof Error ? error.message : 'Unknown file explorer watcher error',
 				code:
 					error instanceof Error && 'code' in error && typeof error.code === 'string'
 						? error.code
 						: undefined,
-				depth: FILE_EXPLORER_WATCH_DEPTH,
 				limit: FILE_EXPLORER_WATCH_LIMIT
 			})
 		})
 
-		subscription.on('all', async (event, targetPath, targetPathNext) => {
+		watcher.on('all', async (event, targetPath, targetPathNext) => {
 			try {
 				if (shouldIgnorePath(targetPath)) return
 
@@ -167,19 +210,25 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 				}
 
 				if (event === 'add' || event === 'addDir') {
+					entry.addCount++
 					visibleAddCount++
 					if (visibleAddCount >= FILE_EXPLORER_WATCH_LIMIT) {
-						sendLimitWarning()
+						sendLimitWarning(rootPath)
 					}
 				}
 
+				if (event === 'unlink' || event === 'unlinkDir') {
+					entry.addCount = Math.max(0, entry.addCount - 1)
+					visibleAddCount = Math.max(0, visibleAddCount - 1)
+				}
+
 				// eslint-disable-next-line no-useless-escape
-				const relativePath = targetPath.replace(folderPath, '').replace(/^[\/\\]/, '')
+				const relativePath = targetPath.replace(rootPath, '').replace(/^[\/\\]/, '')
 
 				let relativePathNext = ''
 				if (targetPathNext) {
 					// eslint-disable-next-line no-useless-escape
-					relativePathNext = targetPathNext.replace(folderPath, '').replace(/^[\/\\]/, '')
+					relativePathNext = targetPathNext.replace(rootPath, '').replace(/^[\/\\]/, '')
 				}
 
 				// Make sure the path is not the root folder
@@ -190,7 +239,7 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 				const nextPathParts = relativePathNext.split(sep)
 
 				const fsEvent: FSEvent = {
-					directoryPath: folderPath,
+					directoryPath: rootPath,
 					event,
 					targetPath,
 					targetPathNext: targetPathNext ?? '',
@@ -205,17 +254,95 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 				queueFSEvent(fsEvent)
 			} catch (error) {
 				sendFSError({
-					directoryPath: folderPath,
+					directoryPath: subPath,
 					message: error instanceof Error ? error.message : 'Unknown file explorer update error',
 					code:
 						error instanceof Error && 'code' in error && typeof error.code === 'string'
 							? error.code
 							: undefined,
-					depth: FILE_EXPLORER_WATCH_DEPTH,
 					limit: FILE_EXPLORER_WATCH_LIMIT
 				})
 			}
 		})
+	}
+
+	// The main window does not exist at handler-registration time (see
+	// `handleEvents` runs before `createWindow` in `src/main/index.ts`), so
+	// we lazily bind the teardown listener once the window becomes available.
+	let boundTeardownWindow: BrowserWindow | null = null
+	const bindTeardownIfNeeded = (): void => {
+		const mainWindow = getMainWindow?.()
+		if (!mainWindow || boundTeardownWindow === mainWindow) return
+		boundTeardownWindow = mainWindow
+		mainWindow.on('closed', () => {
+			clearPendingFSEvents()
+			closeAllWatchers()
+			currentRoot = null
+			boundTeardownWindow = null
+		})
+	}
+
+	// Fetch the contents of the given folder. Also serves as the entry point
+	// for root loads: closes any existing watchers, resets the aggregate
+	// counter, and delegates to the same lazy-expand path used for subfolders.
+	ipcMain.handle('fetch-folder-contents', async (_, folderPath: string) => {
+		if (folderPath === '' || folderPath === undefined || folderPath === null) return
+
+		bindTeardownIfNeeded()
+
+		clearPendingFSEvents()
+		closeAllWatchers()
+
+		currentRoot = folderPath
+
+		startWatcher(folderPath, folderPath)
+	})
+
+	// Lazily expand a subfolder. Open-close-open within the teardown delay is
+	// idempotent: it cancels the pending teardown rather than churning the
+	// watcher.
+	ipcMain.handle('expand-folder', async (_, subPath: string) => {
+		if (!subPath || !currentRoot) return
+
+		const existing = watchers.get(subPath)
+		if (existing) {
+			if (existing.pendingTeardownTimer) {
+				clearTimeout(existing.pendingTeardownTimer)
+				existing.pendingTeardownTimer = null
+			}
+			return
+		}
+
+		startWatcher(currentRoot, subPath)
+	})
+
+	// Lazily collapse a subfolder. The watcher stays alive for
+	// COLLAPSE_TEARDOWN_DELAY_MS so quick re-expand costs nothing; only after
+	// the delay elapses does the watcher close and its contribution to the
+	// aggregate visible-add counter get reclaimed. Collapsing the root is a
+	// no-op - root's watcher only closes when `fetch-folder-contents` is
+	// called again or on app teardown.
+	ipcMain.handle('collapse-folder', async (_, subPath: string) => {
+		if (!subPath) return
+
+		if (currentRoot && subPath === currentRoot) {
+			// Guard against nonsensical collapse-of-root - see design in #110.
+			console.debug('collapse-folder called on root; ignoring', subPath)
+			return
+		}
+
+		const entry = watchers.get(subPath)
+		if (!entry) return
+
+		if (entry.pendingTeardownTimer) {
+			// Already scheduled; keep the existing timer rather than resetting
+			// the countdown.
+			return
+		}
+
+		entry.pendingTeardownTimer = setTimeout(() => {
+			teardownWatcher(subPath)
+		}, COLLAPSE_TEARDOWN_DELAY_MS)
 	})
 
 	// Save a string to a file
@@ -257,4 +384,5 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 			console.error(error)
 		}
 	})
+
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,16 @@
 import { contextBridge, webUtils } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 
+// The file explorer uses these renderer -> main IPC channels (handled in
+// `src/main/event-handlers/filesystem.ts`):
+//   - `fetch-folder-contents(root)`    open a root, close all watchers
+//   - `expand-folder(subPath)`         start a non-recursive watcher lazily
+//   - `collapse-folder(subPath)`       schedule watcher teardown (see
+//                                      COLLAPSE_TEARDOWN_DELAY_MS in
+//                                      `src/shared/constants.ts`)
+// `electronAPI.ipcRenderer.invoke` accepts arbitrary channel strings, so no
+// per-channel type is required here.
+
 // Custom APIs for renderer
 const api = {
   getFilePath: (file: File): string => {

--- a/src/renderer/src/components/MenuPanel/components/FileExplorer/components/DraggableEntry/DraggableEntry.tsx
+++ b/src/renderer/src/components/MenuPanel/components/FileExplorer/components/DraggableEntry/DraggableEntry.tsx
@@ -1,6 +1,6 @@
 import { useDraggable, useDroppable } from '@dnd-kit/core'
 import FileEntry from '../FileEntry/FileEntry'
-import { FileSystemNode } from '@renderer/contexts/DirectoryContext'
+import { DirectoryContext, FileSystemNode } from '@renderer/contexts/DirectoryContext'
 
 import styles from './DraggableEntry.module.css'
 import { MouseEvent, useContext, useEffect, useState } from 'react'
@@ -23,8 +23,33 @@ function DraggableEntry({
 	const type = node.children ? 'folder' : (node.name.endsWith('.tif') || node.name.endsWith('.tiff')) ? 'image' : 'file'
 	const isFolder = type === 'folder'
 	const isEmpty = !node.children || Object.keys(node.children).length === 0
+	// With lazy expansion an unopened folder starts with an empty children
+	// map. We still want to show a chevron so the user can expand it; the
+	// contents (or true emptiness) become visible once the main-side watcher
+	// streams the initial batch.
+	const showChevron = isFolder
 
 	const [isCollapsed, setIsCollapsed] = useState(true)
+
+	const { expandFolder, collapseFolder } = useContext(DirectoryContext)
+
+	// Dispatch expand/collapse to the main-side watcher manager alongside the
+	// existing visual toggle. Idempotent by design: main-side handlers no-op
+	// when the state already matches, and the visual toggle is instant while
+	// the fetch runs asynchronously.
+	const toggleCollapsed = (): void => {
+		setIsCollapsed((prev) => {
+			const next = !prev
+			if (isFolder) {
+				if (next) {
+					collapseFolder(node.path)
+				} else {
+					expandFolder(node.path)
+				}
+			}
+			return next
+		})
+	}
 
 	const { attributes, listeners, setNodeRef } = useDraggable({
 		id: node.path,
@@ -74,12 +99,12 @@ function DraggableEntry({
 			<div
 				className={isFolder ? (isEmpty ? styles.emptyFolder : styles.folder) : styles.file}
 			>
-				{!isEmpty && (
+				{showChevron && (
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
 						viewBox="0 0 320 512"
 						className={`${styles.collapseIcon} ${isCollapsed ? '' : styles.collapseIconOpen}`}
-						onClick={() => setIsCollapsed((prev) => !prev)}
+						onClick={toggleCollapsed}
 					>
 						<path
 							fill="currentColor"

--- a/src/renderer/src/contexts/DirectoryContext.tsx
+++ b/src/renderer/src/contexts/DirectoryContext.tsx
@@ -1,12 +1,15 @@
 import { joinWithSeparator } from '@renderer/interfaces/file'
 import { AlertContext } from '@renderer/contexts/AlertContext'
-import { JSX, createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { JSX, createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
+import { COLLAPSE_TEARDOWN_DELAY_MS } from '../../../shared/constants'
 
 export type DirectoryContextValue = {
 	nodes: NodeChildren
 	directoryPath: string | null
 	directoryName: string | null
 	setDirectory: (directory: string) => void
+	expandFolder: (subPath: string) => void
+	collapseFolder: (subPath: string) => void
 }
 
 export const DirectoryContext = createContext<DirectoryContextValue>(null as never)
@@ -28,7 +31,6 @@ type FSError = {
 	directoryPath: string
 	message: string
 	code?: string
-	depth: number
 	limit: number
 }
 
@@ -48,6 +50,11 @@ function DirectoryProvider({ children }: { children: React.ReactNode }): JSX.Ele
 	const [nodes, setNodes] = useState<NodeChildren>({})
 	const { addAlert } = useContext(AlertContext)
 
+	// Mirror the main-side collapse teardown: renderer-side state for a
+	// collapsed subfolder is pruned on the same delay. Re-expanding within
+	// the window cancels both timers so the existing slice stays.
+	const pendingCollapseTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
 	const setDirectory = useCallback(
 		(directory: string): void => {
 			// Make sure the directory is not empty
@@ -62,10 +69,50 @@ function DirectoryProvider({ children }: { children: React.ReactNode }): JSX.Ele
 			const directorySplit = directory.split(/[/\\]/)
 			setDirectoryName(directorySplit[directorySplit.length - 1])
 
-			// Clear the folder contents
+			// Clear the folder contents and any pending collapse timers -
+			// they refer to paths under the old root.
+			for (const timer of pendingCollapseTimers.current.values()) {
+				clearTimeout(timer)
+			}
+			pendingCollapseTimers.current.clear()
 			setNodes({})
 		},
 		[directoryPath]
+	)
+
+	const expandFolder = useCallback(
+		(subPath: string): void => {
+			if (!subPath) return
+
+			// Cancel a pending renderer-side prune if we re-expand in time.
+			const timer = pendingCollapseTimers.current.get(subPath)
+			if (timer) {
+				clearTimeout(timer)
+				pendingCollapseTimers.current.delete(subPath)
+			}
+
+			window.electron.ipcRenderer.invoke('expand-folder', subPath)
+		},
+		[]
+	)
+
+	const collapseFolder = useCallback(
+		(subPath: string): void => {
+			if (!subPath) return
+
+			// If a prune is already scheduled for this path, do not restart
+			// the timer.
+			if (pendingCollapseTimers.current.has(subPath)) return
+
+			window.electron.ipcRenderer.invoke('collapse-folder', subPath)
+
+			const timer = setTimeout(() => {
+				pendingCollapseTimers.current.delete(subPath)
+				setNodes((prev) => pruneSubtree(prev, subPath))
+			}, COLLAPSE_TEARDOWN_DELAY_MS)
+			pendingCollapseTimers.current.set(subPath, timer)
+		},
+		[]
 	)
 
 	useEffect(() => {
@@ -114,8 +161,27 @@ function DirectoryProvider({ children }: { children: React.ReactNode }): JSX.Ele
 		refreshDirectory()
 	}, [directoryPath])
 
+	// Clear any pending collapse timers on provider teardown.
+	useEffect(() => {
+		return (): void => {
+			for (const timer of pendingCollapseTimers.current.values()) {
+				clearTimeout(timer)
+			}
+			pendingCollapseTimers.current.clear()
+		}
+	}, [])
+
 	return (
-		<DirectoryContext.Provider value={{ nodes, directoryPath, directoryName, setDirectory }}>
+		<DirectoryContext.Provider
+			value={{
+				nodes,
+				directoryPath,
+				directoryName,
+				setDirectory,
+				expandFolder,
+				collapseFolder
+			}}
+		>
 			{children}
 		</DirectoryContext.Provider>
 	)
@@ -215,4 +281,42 @@ function handleFSEvent(nodes: NodeChildren, fsEvent: FSEvent): NodeChildren {
 	}
 
 	return nodesCopy
+}
+
+/**
+ * Drop the children of the folder identified by `subPath` from the nested
+ * `nodes` map, leaving the folder itself in place so its collapsed shell can
+ * still render. The folder is located by walking the tree and matching each
+ * node's absolute `path`; this keeps the reducer independent of the current
+ * root because `path` is the absolute filesystem path already.
+ */
+export function pruneSubtree(nodes: NodeChildren, subPath: string): NodeChildren {
+	if (!subPath) return nodes
+
+	let mutated = false
+	const walk = (children: NodeChildren): NodeChildren => {
+		let next: NodeChildren | null = null
+		for (const key of Object.keys(children)) {
+			const node = children[key]
+			if (node.path === subPath) {
+				if (node.children && Object.keys(node.children).length > 0) {
+					if (!next) next = { ...children }
+					next[key] = { ...node, children: {} }
+					mutated = true
+				}
+				continue
+			}
+			if (node.children) {
+				const walked = walk(node.children)
+				if (walked !== node.children) {
+					if (!next) next = { ...children }
+					next[key] = { ...node, children: walked }
+				}
+			}
+		}
+		return next ?? children
+	}
+
+	const result = walk(nodes)
+	return mutated ? result : nodes
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,0 +1,13 @@
+// Cross-surface constants shared between the Electron main process and the
+// renderer. Keep this file dependency-free so both bundles can import it
+// without pulling in Node- or DOM-specific modules.
+
+/**
+ * How long to wait after the renderer collapses a folder before the main
+ * process closes the watcher on that folder and the renderer prunes the
+ * matching subtree from state. If the user re-expands the folder before this
+ * timer elapses, both teardowns are cancelled and existing state is kept.
+ *
+ * See documentation/docs/reference/technical-constants.md for the rationale.
+ */
+export const COLLAPSE_TEARDOWN_DELAY_MS = 30_000

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
 	"extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
-	"include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*"],
+	"include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*", "src/shared/**/*"],
 	"compilerOptions": {
 		"composite": true,
 		"types": ["electron-vite/node"]

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -4,7 +4,8 @@
 		"src/renderer/src/env.d.ts",
 		"src/renderer/src/**/*",
 		"src/renderer/src/**/*.tsx",
-		"src/preload/*.d.ts"
+		"src/preload/*.d.ts",
+		"src/shared/**/*"
 	],
 	"compilerOptions": {
 		"composite": true,
@@ -13,6 +14,9 @@
 		"paths": {
 			"@renderer/*": [
 				"src/renderer/src/*"
+			],
+			"@shared/*": [
+				"src/shared/*"
 			]
 		}
 	}


### PR DESCRIPTION
Closes #110. Refs #102.

## Summary

Replaces the single recursive `Watcher(root, {recursive:true, depth:6, limit})`
in `src/main/event-handlers/filesystem.ts` with a `Map<path, WatcherEntry>` of
non-recursive watchers. `fetch-folder-contents(root)` closes every open
watcher, resets the aggregate visible-add counter, and starts one watcher on
the root - root is now just a distinguished expanded folder. Two new IPC
handlers drive lazy loading:

- `expand-folder(subPath)` starts a non-recursive watcher on `subPath` (or
  cancels a pending teardown if one is queued, making open-close-open
  idempotent).
- `collapse-folder(subPath)` schedules teardown of the subPath watcher after
  `COLLAPSE_TEARDOWN_DELAY_MS` (30_000 ms). Cancelled by a subsequent
  `expand-folder(subPath)`. Root is exempt; collapse-of-root is a no-op.

`FILE_EXPLORER_WATCH_DEPTH` is removed. `FILE_EXPLORER_WATCH_LIMIT` is kept
but its role changes from a per-watcher `watcher`-package limit to an
aggregate session budget summed across every open watcher; a watcher's
contribution is reclaimed on teardown.

`src/shared/constants.ts` is a new dependency-free module holding
`COLLAPSE_TEARDOWN_DELAY_MS` so both the main process and the renderer import
the same value. `tsconfig.node.json` and `tsconfig.web.json` include it;
`electron.vite.config.ts` gets an `@shared` alias.

Renderer:

- `DirectoryContext` exposes `expandFolder(subPath)` and `collapseFolder(subPath)`.
  Collapse mirrors the main-side timing with a state prune scheduled via
  `pruneSubtree(subPath)`; re-expanding within the window cancels both timers.
  Switching the root clears all pending timers.
- `DraggableEntry` dispatches expand/collapse alongside its existing visual
  `isCollapsed` toggle. Idempotent - main-side handlers no-op when state
  already matches. The chevron now renders on every folder (not just
  non-empty ones) so an unopened lazy folder is expandable.
- The `nodes: {}` IFrame broadcast is unchanged; no plugin-facing API in
  this PR (that lands in #111).

`src/preload/index.ts` documents the new IPC channels; the electron-toolkit
preload accepts arbitrary channel strings so no per-channel type is required.

## Acceptance criteria (from #110)

- [x] Opening a 100k-file folder produces state and events only for root's
  direct entries. (Root is watched non-recursively; batches only include
  root's direct children until subfolders are expanded.)
- [x] Expanding a subfolder streams that folder's direct entries only, no
  recursion. (New non-recursive watcher per expanded folder.)
- [x] Collapsing a subfolder drops its state after the delay unless
  re-expanded first. (Both main-side watcher teardown and renderer-side
  `pruneSubtree` are scheduled on `COLLAPSE_TEARDOWN_DELAY_MS` and are
  cancelled by a subsequent expand.)
- [x] File selection, drag-drop between folders, and new-folder uniqueness
  (`FileExplorer.tsx:80` `isUsed`) continue to work. (No changes to the
  `NodeChildren` shape; `handleFSEvent` still populates the nested map from
  batch events, only lazily.)
- [x] `npm run typecheck` passes. (Verified locally; see below.)
- [x] Documented in `documentation/docs/index.md` (Large Folder Behavior)
  and `documentation/docs/reference/technical-constants.md`
  (`COLLAPSE_TEARDOWN_DELAY_MS` added; `FILE_EXPLORER_WATCH_DEPTH` removed;
  `FILE_EXPLORER_WATCH_LIMIT` role clarified).

## Design notes / minor divergences

- **Chevron visibility change.** The pre-existing `DraggableEntry` hid the
  chevron for empty folders (`!isEmpty`). Under lazy loading a folder starts
  with `children: {}` until first expand, so `!isEmpty` would hide the chevron
  on every not-yet-expanded folder and there would be no way to expand it.
  The chevron now shows on every folder regardless. True empty folders are
  still visually distinguished by the `emptyFolder` style.
- **Main-window teardown listener.** `handleEvents` runs before
  `createWindow`, so `getMainWindow()` returns undefined at
  handler-registration time. The window `closed` listener is bound lazily on
  the first `fetch-folder-contents` call and rebinds if the window is
  recreated (e.g. macOS reactivation).
- **Per-watcher `addCount` also tracks unlinks.** When an `unlink` /
  `unlinkDir` event fires, both the per-watcher and aggregate counters
  decrement. This keeps the aggregate budget honest across long-lived
  sessions where files come and go without triggering false limit warnings.
- **`pruneSubtree` reducer.** Renderer-side prune walks the nested `nodes`
  map by absolute `path` equality (not by root-relative path decomposition)
  because `FileSystemNode.path` is already absolute; this keeps the reducer
  independent of the current root and makes it work uniformly for any
  subPath the main process might collapse.

## Blockers / pre-existing issues

- `npm run lint` fails with `ESLint couldn't find an eslint.config.(js|mjs|cjs) file`.
  This is the pre-existing ESLint 9 config drift called out in PR #109; not
  introduced by this PR and not addressed here.
- Manual smoke via `npm run dev` was not attempted; the automation host has
  no reachable display. A reviewer can run `npm run dev`, open a mid-size
  folder, and expand/collapse a subfolder to visually confirm:
  1. Initial open shows only root's direct entries in the panel.
  2. Clicking the chevron on a subfolder loads its direct children.
  3. Collapsing then re-expanding within ~30 seconds is instant with no
     visible re-fetch flicker.
  4. Collapsing and leaving collapsed for >30 seconds, then re-expanding,
     shows a fresh load.

## Verification commands

```
npm ci                # completed
npm run typecheck     # passes (both tsconfig.node.json and tsconfig.web.json)
npm run lint          # fails with pre-existing ESLint 9 config drift; see above
```

## Files changed

- `src/main/event-handlers/filesystem.ts` - watcher-manager rewrite +
  `expand-folder` / `collapse-folder` handlers.
- `src/renderer/src/contexts/DirectoryContext.tsx` - new
  `expandFolder` / `collapseFolder` methods, `pruneSubtree` reducer,
  timer bookkeeping.
- `src/renderer/src/components/MenuPanel/components/FileExplorer/components/DraggableEntry/DraggableEntry.tsx` -
  dispatch expand/collapse on chevron click; always show chevron on folders.
- `src/shared/constants.ts` - new; `COLLAPSE_TEARDOWN_DELAY_MS`.
- `src/preload/index.ts` - documenting comment for the new IPC channels.
- `tsconfig.node.json`, `tsconfig.web.json`, `electron.vite.config.ts` -
  include `src/shared/**/*` and register the `@shared` alias.
- `documentation/docs/index.md` - Large Folder Behavior rewritten for the
  lazy model.
- `documentation/docs/reference/technical-constants.md` -
  `FILE_EXPLORER_WATCH_DEPTH` removed, `FILE_EXPLORER_WATCH_LIMIT` role
  clarified, `COLLAPSE_TEARDOWN_DELAY_MS` documented.