### PR TITLE
feat(iframe): plugin directory request API with recursive semantics

### DIFF
--- a/documentation/docs/guide/plugins.md
+++ b/documentation/docs/guide/plugins.md
@@ -43,10 +43,70 @@ See the [template README](https://github.com/ChengLabResearch/ouroboros/blob/mai
 When Ouroboros posts a `send-directory-contents` message to plugin
 iframes, the payload contains the selected directory's `directoryPath`
 and `directoryName` but the `nodes` field is always an empty object.
-Plugins should not depend on receiving the full recursive file tree
-through this broadcast. An on-demand plugin file API is being designed;
-until it lands, use `read-file` and `save-file` requests for the
-specific paths a plugin needs.
+This broadcast fires on every root change and is intended as a
+notification only — plugins should not depend on receiving the full
+recursive file tree through it.
+
+To read the directory tree, plugins request it explicitly with the
+`request-directory-contents` message described below.
+
+### Requesting Directory Contents
+
+Plugins ask the provider for the entries of a folder (optionally
+recursive) by posting a `request-directory-contents` message. The
+provider replies with a `send-directory-contents-response` message
+addressed only to the requesting iframe.
+
+**Request (plugin → provider):**
+
+```js
+window.parent.postMessage(
+    {
+        type: 'request-directory-contents',
+        data: {
+            path: '/absolute/path/under/current/root',
+            recursive: true,        // optional; defaults to false
+            requestId: 'abc-123'    // optional; the provider echoes it back
+        }
+    },
+    '*'
+)
+```
+
+**Response (provider → requesting iframe):**
+
+```js
+window.addEventListener('message', (event) => {
+    if (event.data?.type !== 'send-directory-contents-response') return
+    const { path, nodes, requestId, error } = event.data.data
+    // `nodes` is a path-keyed nested map of { name, path, children? }
+    // matching the shape the pre-#106 broadcast used.
+    // `error` is present only when the request could not be fully served:
+    //   - code: 'denied'     path outside the current root, or no root open
+    //   - code: 'not-found'  path does not exist / is not a directory
+    //   - code: 'limit'      enumeration hit the aggregate cap; `truncated: true`
+    //                        and `nodes` holds the partial result
+    //   - code: 'internal'   unexpected error; see `message`
+})
+```
+
+If `requestId` is omitted from the request, the provider generates one
+and echoes it back on the response so plugins can still correlate.
+
+**Path-traversal guard.** Requests for paths outside the current root are
+rejected with `code: 'denied'`. Plugins get exactly what the user can see
+in the File Explorer and nothing above it.
+
+**Truncation.** When the aggregate visible-path budget
+(`FILE_EXPLORER_WATCH_LIMIT`) is exceeded mid-walk, the enumeration stops
+and the response is returned with `error.code: 'limit'`,
+`error.truncated: true`, and a partial `nodes` map. Callers issuing
+recursive requests on very large trees should be prepared to handle
+this.
+
+**Ignore rules.** The same ignore filter the File Explorer uses (dotfiles
+and the `node_modules`, `__pycache__`, `venv` segments) applies here.
+Plugins cannot bypass it.
 
 For details and the values behind other file explorer limits, see the
 [Technical Constants](../reference/technical-constants.md) reference.

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -31,15 +31,23 @@ _It is recommended that you read these pages in order._
 ## Large Folder Behavior
 
 The Ouroboros File Explorer is designed to open scan and output folders
-directly, but it is not a general-purpose file browser. When you point it
-at a folder that contains many files or deeply nested subfolders, the
-following limits apply:
+directly, but it is not a general-purpose file browser. It loads
+subfolders on demand: opening a folder shows only that folder's direct
+entries, and subfolder contents stream in when you expand each subfolder.
+When you point it at a folder that contains many files or deeply nested
+subfolders, the following behavior applies:
 
-- Only the first six directory levels below the folder you open are
-  walked.
+- Only the root's direct entries are loaded up front. Nested subfolders
+  are loaded and watched only when you expand them.
+- Collapsing a subfolder keeps its state and watcher alive for a short
+  window (thirty seconds by default) so quickly re-expanding is free. If
+  you leave it collapsed past that window, the underlying watcher is torn
+  down and the subfolder's cached children are dropped from renderer
+  state; re-expanding later behaves like a fresh load.
 - The panel stops loading new paths after one hundred thousand visible
-  entries. When this happens, Ouroboros shows a warning toast asking you
-  to pick a smaller folder or expand the folder in smaller pieces.
+  entries across all currently open watchers. When this happens,
+  Ouroboros shows a warning toast asking you to pick a smaller folder or
+  expand the folder in smaller pieces.
 - `node_modules`, `__pycache__`, `venv`, and any directory whose name
   starts with `.` are always skipped.
 

--- a/documentation/docs/reference/technical-constants.md
+++ b/documentation/docs/reference/technical-constants.md
@@ -8,59 +8,78 @@ source. If you change them locally, update this page in the same commit.
 
 All file explorer limits live in
 [`src/main/event-handlers/filesystem.ts`][filesystem-ts] at the top of the
-file. They apply to the recursive watcher that backs the File Explorer
-panel in the Electron app.
+file, alongside the shared teardown delay in
+[`src/shared/constants.ts`][shared-constants-ts]. They apply to the
+per-directory non-recursive watchers with lazy expansion that back the
+File Explorer panel in the Electron app.
 
-### Watcher depth limit
-
-- Symbol: `FILE_EXPLORER_WATCH_DEPTH`
-- Value: `6`
-- Source: [`src/main/event-handlers/filesystem.ts`][filesystem-ts] line 8
-- Also passed to the underlying `watcher` package as its `depth` option and
-  reported inside every `folder-contents-error` payload.
-
-**Why it exists.** The file explorer used to open folders with an
-unbounded recursive watcher. Deep dependency trees, build outputs, or
-scientific datasets could push watcher and renderer state well past the
-V8 heap and trigger the crash described in [#51][issue-51].
-
-**User-visible behavior when reached.** Directories nested more than six
-levels below the selected root are simply not walked, so their contents do
-not appear in the File Explorer panel. The panel still works normally at
-shallower depths.
-
-**When to reconsider.** Raise this if you routinely need to see files
-deeper than six levels from the folder you open in Ouroboros and you have
-already excluded large auxiliary trees (see the ignored segments below).
-Prefer opening a lower-level folder before increasing the constant.
+Starting with [#110][pr-110], the file explorer no longer opens a single
+recursive watcher on the selected root. Instead, the main process keeps
+one non-recursive watcher per directory the user has currently expanded,
+plus one for the root. Expanding a subfolder starts a new watcher for it;
+collapsing schedules teardown after
+[`COLLAPSE_TEARDOWN_DELAY_MS`](#watcher-teardown-delay-after-collapse),
+so quick collapse-then-reopen costs nothing.
 
 ### Watcher path-count limit
 
 - Symbol: `FILE_EXPLORER_WATCH_LIMIT`
 - Value: `100_000`
 - Source: [`src/main/event-handlers/filesystem.ts`][filesystem-ts] line 9
-- Passed to the underlying `watcher` package as its `limit` option and
-  reported inside every `folder-contents-error` payload.
+- Reported inside every `folder-contents-error` payload.
 
-**Why it exists.** The watcher mirrors every discovered path into
-renderer state. Very large folders can therefore multiply main-process
-watcher memory with renderer heap. One hundred thousand visible paths is
-the ceiling picked in [#104][pr-104] as a balance between usefulness for
-typical scan/output folders and keeping the renderer well under its
-default 4 GB heap.
+**Why it exists.** Every watcher mirrors its discovered paths into
+renderer state. Even with lazy expansion, an aggressive user could open a
+handful of dense subfolders in sequence and still exhaust memory. One
+hundred thousand visible paths is the ceiling picked in [#104][pr-104] as
+a balance between usefulness for typical scan/output folders and keeping
+the renderer well under its default 4 GB heap.
 
-**User-visible behavior when reached.** Once the visible add count crosses
-the limit, the main process emits `folder-contents-error` with a message
-of the form `File explorer stopped loading after 100000 visible paths.
-Choose a smaller folder or expand the folder in smaller pieces.` The
-existing renderer alert system surfaces this as a warning toast. The
-watcher stops delivering further add events for that session; already
-loaded paths remain visible.
+**Role change from #110.** Before #110 this was the underlying `watcher`
+package's per-watcher `limit`. Under the lazy model it is instead an
+aggregate session budget summed across every currently open watcher; a
+watcher's contribution is reclaimed when its folder is collapsed and torn
+down.
+
+**User-visible behavior when reached.** Once the aggregate visible add
+count crosses the limit, the main process emits `folder-contents-error`
+with a message of the form `File explorer stopped loading after 100000
+visible paths across all open folders. Choose a smaller folder or expand
+the folder in smaller pieces.` The existing renderer alert system
+surfaces this as a warning toast. Further add events for that session are
+not attributed to the counter but already loaded paths remain visible.
 
 **When to reconsider.** Raise this only after profiling shows headroom in
-both the main watcher and the renderer heap for your typical workload.
+both the main watchers and the renderer heap for your typical workload.
 Lower it if you routinely work on constrained machines and want the
 warning to appear sooner.
+
+### Watcher teardown delay after collapse
+
+- Symbol: `COLLAPSE_TEARDOWN_DELAY_MS`
+- Value: `30_000` (milliseconds)
+- Source: [`src/shared/constants.ts`][shared-constants-ts]
+
+**Why it exists.** Collapsing a folder in the file explorer should not
+immediately close its watcher and drop its renderer state, because users
+routinely collapse-then-reopen the same folder while navigating. The
+delay makes that pattern free: as long as the user re-expands within
+thirty seconds, no watcher churn and no state re-fetch happen. After the
+delay elapses, the main process closes the non-recursive watcher on the
+collapsed subfolder and the renderer prunes its children from state.
+Root's watcher is exempt - collapsing root is a no-op; root's watcher
+only closes when a new root is opened or the window is torn down.
+
+**User-visible behavior when reached.** Nothing visible changes at the
+moment of teardown. The collapsed folder's shell remains rendered; its
+children have already stopped rendering visually because of the collapse.
+Re-expanding after teardown behaves like a fresh expand: the main process
+starts a new watcher and streams the initial batch back into the
+renderer's state.
+
+**When to reconsider.** Shorten if renderer memory pressure from
+still-cached collapsed subtrees is a problem. Lengthen if users complain
+that re-opening a folder after a long detour repopulates it visibly.
 
 ### Update batch size
 
@@ -519,12 +538,17 @@ filename together, since the artifact filename embeds the tag.
 ## Where the values come from
 
 Every value above was read directly from the tree at the time this page
-was written. The five file explorer constants live together as a block at
-the top of [`src/main/event-handlers/filesystem.ts`][filesystem-ts]
-(lines 8-12). If you edit any of them, update this page in the same
-commit so operators and plugin authors can rely on it.
+was written. The remaining file explorer constants live together as a
+block at the top of
+[`src/main/event-handlers/filesystem.ts`][filesystem-ts]; the shared
+teardown delay lives in [`src/shared/constants.ts`][shared-constants-ts]
+so both the main process and the renderer import the same value. If you
+edit any of them, update this page in the same commit so operators and
+plugin authors can rely on it.
 
 [filesystem-ts]: https://github.com/ChengLabResearch/ouroboros/blob/main/src/main/event-handlers/filesystem.ts
+[shared-constants-ts]: https://github.com/ChengLabResearch/ouroboros/blob/main/src/shared/constants.ts
+[pr-110]: https://github.com/ChengLabResearch/ouroboros/pull/110
 [iframe-context]: https://github.com/ChengLabResearch/ouroboros/blob/main/src/renderer/src/contexts/IFrameContext.tsx
 [file-server-ts]: https://github.com/ChengLabResearch/ouroboros/blob/main/src/main/servers/file-server.ts
 [file-server-script]: https://github.com/ChengLabResearch/ouroboros/blob/main/resources/processes/file-server-script.mjs

--- a/documentation/docs/reference/technical-constants.md
+++ b/documentation/docs/reference/technical-constants.md
@@ -41,6 +41,17 @@ aggregate session budget summed across every currently open watcher; a
 watcher's contribution is reclaimed when its folder is collapsed and torn
 down.
 
+**Second role from #111.** The same constant caps the plugin-facing
+`get-folder-contents` one-shot enumeration used by the
+`request-directory-contents` iframe message (see the [plugins
+guide](../guide/plugins.md#requesting-directory-contents)). A plugin's
+recursive walk stops when the enumeration hits the cap; the response is
+returned with `error.code: 'limit'` and `error.truncated: true`, and
+`nodes` holds the partial result already gathered. Enumeration and
+watcher budgets are counted separately (the enumeration count is
+per-request and does not accumulate across requests), so a plugin cannot
+starve the file explorer by issuing many recursive requests.
+
 **User-visible behavior when reached.** Once the aggregate visible add
 count crosses the limit, the main process emits `folder-contents-error`
 with a message of the form `File explorer stopped loading after 100000
@@ -140,14 +151,16 @@ costs above.
 **User-visible behavior.** Plugins still receive the selected directory
 path and name through the existing `send-directory-contents` message.
 The `nodes` field is present for shape compatibility but is always an
-empty object. Plugins that need to browse the directory tree should not
-depend on this broadcast; the on-demand plugin file API tracked by
-[#102][issue-102] is the intended replacement.
+empty object. Plugins that need to browse the directory tree use the
+`request-directory-contents` / `send-directory-contents-response`
+message pair added in [#111][issue-111] (see the [plugins
+guide](../guide/plugins.md#requesting-directory-contents)) rather than
+depending on this broadcast payload.
 
 **When to reconsider.** Do not restore the full-tree broadcast without
-first landing a memory-safe, on-demand alternative. If you need a
-minimal listing for a plugin, prefer adding a targeted IPC call over
-resurrecting the broadcast.
+first landing a memory-safe, on-demand alternative. The on-demand API
+from #111 is that alternative; prefer extending it over resurrecting
+the broadcast.
 
 ## Main process (Electron)
 

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -18,7 +18,8 @@ export default defineConfig({
 	renderer: {
 		resolve: {
 			alias: {
-				'@renderer': resolve('src/renderer/src')
+				'@renderer': resolve('src/renderer/src'),
+				'@shared': resolve('src/shared')
 			}
 		},
 		plugins: [

--- a/src/main/event-handlers/filesystem.ts
+++ b/src/main/event-handlers/filesystem.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow, IpcMain } from 'electron'
-import { rename, rm, stat } from 'fs/promises'
+import { readdir, rename, rm, stat } from 'fs/promises'
 import { basename, join, relative, sep } from 'path'
 import Watcher from 'watcher'
 
@@ -7,9 +7,122 @@ import { readFile, saveFile } from '../helpers'
 import { COLLAPSE_TEARDOWN_DELAY_MS } from '../../shared/constants'
 
 const FILE_EXPLORER_WATCH_LIMIT = 100_000
+// `FILE_EXPLORER_WATCH_LIMIT` doubles as the aggregate enumeration cap for the
+// plugin-facing `get-folder-contents` walk. Reusing the same constant keeps
+// the two paths (watcher-driven state and one-shot enumerations) bounded by
+// a single visible budget: a plugin cannot force the renderer to hold more
+// paths in memory than a user can force through the file explorer.
 const FILE_EXPLORER_UPDATE_BATCH_LIMIT = 500
 const FILE_EXPLORER_UPDATE_INTERVAL_MS = 100
 const IGNORED_PATH_SEGMENTS = new Set(['node_modules', '__pycache__', 'venv'])
+
+// One-shot ignore rule shared by the watcher factory and the plugin-facing
+// `get-folder-contents` enumeration. `rootPath` is the top of the tree the
+// enumeration is scoped to; entries outside it are treated as ignored so
+// symlink escapes fall through.
+function shouldIgnorePathAgainstRoot(rootPath: string, targetPath: string): boolean {
+	const targetRelativePath = relative(rootPath, targetPath)
+
+	if (!targetRelativePath || targetRelativePath === '') return false
+	if (targetRelativePath.startsWith('..')) return false
+
+	const pathSegments = targetRelativePath.split(/[\\/]/)
+	return pathSegments.some((segment) => {
+		if (segment.startsWith('.')) return true
+		return IGNORED_PATH_SEGMENTS.has(segment)
+	})
+}
+
+type PluginFSNode = {
+	name: string
+	path: string
+	children?: { [key: string]: PluginFSNode }
+}
+
+type PluginNodeChildren = { [key: string]: PluginFSNode }
+
+type GetFolderContentsOptions = {
+	recursive?: boolean
+	rootPath?: string
+}
+
+type GetFolderContentsResult = {
+	nodes: PluginNodeChildren
+	truncated: boolean
+}
+
+// One-shot directory read used by the plugin-facing request API. Does not
+// start a watcher and does not touch the watcher-manager state. `rootPath`
+// defaults to `folderPath` when the caller doesn't scope enumeration to a
+// broader root (used by the traversal-guarded plugin handler).
+async function getFolderContents(
+	folderPath: string,
+	options: GetFolderContentsOptions = {}
+): Promise<GetFolderContentsResult> {
+	const recursive = options.recursive ?? false
+	const rootPath = options.rootPath ?? folderPath
+
+	const nodes: PluginNodeChildren = {}
+	// Track aggregate entries against the same visible budget as the watcher
+	// path. `count` includes files and directories the caller will actually
+	// see in `nodes`; ignored entries don't count against the budget.
+	let count = 0
+	let truncated = false
+
+	const walk = async (dirPath: string, target: PluginNodeChildren): Promise<void> => {
+		if (truncated) return
+
+		const entries = await readdir(dirPath, { withFileTypes: true })
+		for (const entry of entries) {
+			if (truncated) return
+
+			const entryPath = join(dirPath, entry.name)
+			if (shouldIgnorePathAgainstRoot(rootPath, entryPath)) continue
+
+			if (count >= FILE_EXPLORER_WATCH_LIMIT) {
+				truncated = true
+				return
+			}
+			count++
+
+			const node: PluginFSNode = {
+				name: entry.name,
+				path: entryPath
+			}
+
+			if (entry.isDirectory()) {
+				node.children = {}
+				target[entry.name] = node
+				if (recursive) {
+					try {
+						await walk(entryPath, node.children)
+					} catch (err) {
+						// Surface permission errors as a stop-point on that
+						// branch rather than aborting the whole enumeration.
+						// The already-added directory node stays with an
+						// empty `children` map.
+						if (!isEnoentLike(err)) throw err
+					}
+				}
+			} else {
+				target[entry.name] = node
+			}
+		}
+	}
+
+	await walk(folderPath, nodes)
+
+	return { nodes, truncated }
+}
+
+function isEnoentLike(err: unknown): boolean {
+	if (!err || typeof err !== 'object') return false
+	const code = (err as { code?: string }).code
+	return code === 'ENOENT' || code === 'EACCES' || code === 'EPERM'
+}
+
+export { getFolderContents, shouldIgnorePathAgainstRoot }
+export type { PluginNodeChildren, PluginFSNode, GetFolderContentsResult }
 
 type FSEvent = {
 	event: string
@@ -153,18 +266,8 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 	const startWatcher = (rootPath: string, subPath: string): void => {
 		if (watchers.has(subPath)) return
 
-		const shouldIgnorePath = (targetPath: string): boolean => {
-			const targetRelativePath = relative(rootPath, targetPath)
-
-			if (!targetRelativePath || targetRelativePath === '') return false
-			if (targetRelativePath.startsWith('..')) return false
-
-			const pathSegments = targetRelativePath.split(/[\\/]/)
-			return pathSegments.some((segment) => {
-				if (segment.startsWith('.')) return true
-				return IGNORED_PATH_SEGMENTS.has(segment)
-			})
-		}
+		const shouldIgnorePath = (targetPath: string): boolean =>
+			shouldIgnorePathAgainstRoot(rootPath, targetPath)
 
 		const watcher = new Watcher(subPath, {
 			recursive: false,
@@ -344,6 +447,23 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 			teardownWatcher(subPath)
 		}, COLLAPSE_TEARDOWN_DELAY_MS)
 	})
+
+	// One-shot directory read for the plugin-facing request API. Does not
+	// touch the watcher manager; the plugin handler in `IFrameContext.tsx`
+	// is responsible for path-traversal guards and error mapping.
+	// `rootPath` scopes ignore semantics when it differs from `folderPath`,
+	// so a plugin recursing under root gets the same segment filtering the
+	// watcher-driven state does.
+	ipcMain.handle(
+		'get-folder-contents',
+		async (
+			_,
+			args: { folderPath: string; recursive?: boolean; rootPath?: string }
+		): Promise<GetFolderContentsResult> => {
+			const { folderPath, recursive, rootPath } = args
+			return await getFolderContents(folderPath, { recursive, rootPath })
+		}
+	)
 
 	// Save a string to a file
 	ipcMain.handle('save-file', async (_, args) => {

--- a/src/main/event-handlers/filesystem.ts
+++ b/src/main/event-handlers/filesystem.ts
@@ -4,8 +4,8 @@ import { basename, join, relative, sep } from 'path'
 import Watcher from 'watcher'
 
 import { readFile, saveFile } from '../helpers'
+import { COLLAPSE_TEARDOWN_DELAY_MS } from '../../shared/constants'
 
-const FILE_EXPLORER_WATCH_DEPTH = 6
 const FILE_EXPLORER_WATCH_LIMIT = 100_000
 const FILE_EXPLORER_UPDATE_BATCH_LIMIT = 500
 const FILE_EXPLORER_UPDATE_INTERVAL_MS = 100
@@ -28,12 +28,29 @@ type FSError = {
 	directoryPath: string
 	message: string
 	code?: string
-	depth: number
 	limit: number
 }
 
+type WatcherEntry = {
+	watcher: Watcher
+	addCount: number
+	pendingTeardownTimer: NodeJS.Timeout | null
+}
+
 export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => BrowserWindow): void => {
-	let subscription: Watcher | null = null
+	// One non-recursive watcher per currently expanded directory. The root
+	// watcher lives here too - root is just a distinguished expanded folder.
+	const watchers = new Map<string, WatcherEntry>()
+
+	// Aggregate visible-add count across every open watcher in this session.
+	// `FILE_EXPLORER_WATCH_LIMIT` is a session budget, not a per-watcher one.
+	let visibleAddCount = 0
+	let sentLimitWarning = false
+
+	// The currently open root. `collapse-folder(root)` is a no-op so we can
+	// guard against nonsensical collapse-of-root requests.
+	let currentRoot: string | null = null
+
 	let pendingFSEvents: FSEvent[] = []
 	let pendingFSEventsTimeout: NodeJS.Timeout | null = null
 
@@ -87,19 +104,57 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 		}
 	}
 
-	// Fetch the contents of the given folder
-	ipcMain.handle('fetch-folder-contents', async (_, folderPath: string) => {
-		if (folderPath === '' || folderPath === undefined || folderPath === null) return
+	const sendLimitWarning = (folderPath: string): void => {
+		if (sentLimitWarning) return
 
-		clearPendingFSEvents()
+		sentLimitWarning = true
+		sendFSError({
+			directoryPath: folderPath,
+			message: `File explorer stopped loading after ${FILE_EXPLORER_WATCH_LIMIT} visible paths across all open folders. Choose a smaller folder or expand the folder in smaller pieces.`,
+			limit: FILE_EXPLORER_WATCH_LIMIT
+		})
+	}
 
-		if (subscription) {
-			subscription.close()
-			subscription = null
+	// Close every open watcher and reset all associated state. Used when the
+	// root changes and on window teardown / app quit.
+	const closeAllWatchers = (): void => {
+		for (const entry of watchers.values()) {
+			if (entry.pendingTeardownTimer) {
+				clearTimeout(entry.pendingTeardownTimer)
+				entry.pendingTeardownTimer = null
+			}
+			entry.watcher.close()
+		}
+		watchers.clear()
+		visibleAddCount = 0
+		sentLimitWarning = false
+	}
+
+	// Tear down a single watcher entry and reclaim its contribution to the
+	// aggregate visible-add counter.
+	const teardownWatcher = (subPath: string): void => {
+		const entry = watchers.get(subPath)
+		if (!entry) return
+
+		if (entry.pendingTeardownTimer) {
+			clearTimeout(entry.pendingTeardownTimer)
+			entry.pendingTeardownTimer = null
 		}
 
+		entry.watcher.close()
+		visibleAddCount = Math.max(0, visibleAddCount - entry.addCount)
+		watchers.delete(subPath)
+	}
+
+	// Start a non-recursive watcher on `subPath`. `rootPath` is the root the
+	// renderer treats as the top of its tree; every batched event's relative
+	// path is computed against it so the renderer's nested `nodes` map lines
+	// up regardless of which folder produced the event.
+	const startWatcher = (rootPath: string, subPath: string): void => {
+		if (watchers.has(subPath)) return
+
 		const shouldIgnorePath = (targetPath: string): boolean => {
-			const targetRelativePath = relative(folderPath, targetPath)
+			const targetRelativePath = relative(rootPath, targetPath)
 
 			if (!targetRelativePath || targetRelativePath === '') return false
 			if (targetRelativePath.startsWith('..')) return false
@@ -111,44 +166,32 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 			})
 		}
 
-		let visibleAddCount = 0
-		let sentLimitWarning = false
-
-		const sendLimitWarning = (): void => {
-			if (sentLimitWarning) return
-
-			sentLimitWarning = true
-			sendFSError({
-				directoryPath: folderPath,
-				message: `File explorer stopped loading after ${FILE_EXPLORER_WATCH_LIMIT} visible paths. Choose a smaller folder or expand the folder in smaller pieces.`,
-				depth: FILE_EXPLORER_WATCH_DEPTH,
-				limit: FILE_EXPLORER_WATCH_LIMIT
-			})
-		}
-
-		// Send updates to the renderer when the folder contents change
-		subscription = new Watcher(folderPath, {
-			recursive: true,
+		const watcher = new Watcher(subPath, {
+			recursive: false,
 			renameDetection: true,
-			depth: FILE_EXPLORER_WATCH_DEPTH,
-			limit: FILE_EXPLORER_WATCH_LIMIT,
 			ignore: shouldIgnorePath
 		})
 
-		subscription.on('error', (error) => {
+		const entry: WatcherEntry = {
+			watcher,
+			addCount: 0,
+			pendingTeardownTimer: null
+		}
+		watchers.set(subPath, entry)
+
+		watcher.on('error', (error) => {
 			sendFSError({
-				directoryPath: folderPath,
+				directoryPath: subPath,
 				message: error instanceof Error ? error.message : 'Unknown file explorer watcher error',
 				code:
 					error instanceof Error && 'code' in error && typeof error.code === 'string'
 						? error.code
 						: undefined,
-				depth: FILE_EXPLORER_WATCH_DEPTH,
 				limit: FILE_EXPLORER_WATCH_LIMIT
 			})
 		})
 
-		subscription.on('all', async (event, targetPath, targetPathNext) => {
+		watcher.on('all', async (event, targetPath, targetPathNext) => {
 			try {
 				if (shouldIgnorePath(targetPath)) return
 
@@ -167,19 +210,25 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 				}
 
 				if (event === 'add' || event === 'addDir') {
+					entry.addCount++
 					visibleAddCount++
 					if (visibleAddCount >= FILE_EXPLORER_WATCH_LIMIT) {
-						sendLimitWarning()
+						sendLimitWarning(rootPath)
 					}
 				}
 
+				if (event === 'unlink' || event === 'unlinkDir') {
+					entry.addCount = Math.max(0, entry.addCount - 1)
+					visibleAddCount = Math.max(0, visibleAddCount - 1)
+				}
+
 				// eslint-disable-next-line no-useless-escape
-				const relativePath = targetPath.replace(folderPath, '').replace(/^[\/\\]/, '')
+				const relativePath = targetPath.replace(rootPath, '').replace(/^[\/\\]/, '')
 
 				let relativePathNext = ''
 				if (targetPathNext) {
 					// eslint-disable-next-line no-useless-escape
-					relativePathNext = targetPathNext.replace(folderPath, '').replace(/^[\/\\]/, '')
+					relativePathNext = targetPathNext.replace(rootPath, '').replace(/^[\/\\]/, '')
 				}
 
 				// Make sure the path is not the root folder
@@ -190,7 +239,7 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 				const nextPathParts = relativePathNext.split(sep)
 
 				const fsEvent: FSEvent = {
-					directoryPath: folderPath,
+					directoryPath: rootPath,
 					event,
 					targetPath,
 					targetPathNext: targetPathNext ?? '',
@@ -205,17 +254,95 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 				queueFSEvent(fsEvent)
 			} catch (error) {
 				sendFSError({
-					directoryPath: folderPath,
+					directoryPath: subPath,
 					message: error instanceof Error ? error.message : 'Unknown file explorer update error',
 					code:
 						error instanceof Error && 'code' in error && typeof error.code === 'string'
 							? error.code
 							: undefined,
-					depth: FILE_EXPLORER_WATCH_DEPTH,
 					limit: FILE_EXPLORER_WATCH_LIMIT
 				})
 			}
 		})
+	}
+
+	// The main window does not exist at handler-registration time (see
+	// `handleEvents` runs before `createWindow` in `src/main/index.ts`), so
+	// we lazily bind the teardown listener once the window becomes available.
+	let boundTeardownWindow: BrowserWindow | null = null
+	const bindTeardownIfNeeded = (): void => {
+		const mainWindow = getMainWindow?.()
+		if (!mainWindow || boundTeardownWindow === mainWindow) return
+		boundTeardownWindow = mainWindow
+		mainWindow.on('closed', () => {
+			clearPendingFSEvents()
+			closeAllWatchers()
+			currentRoot = null
+			boundTeardownWindow = null
+		})
+	}
+
+	// Fetch the contents of the given folder. Also serves as the entry point
+	// for root loads: closes any existing watchers, resets the aggregate
+	// counter, and delegates to the same lazy-expand path used for subfolders.
+	ipcMain.handle('fetch-folder-contents', async (_, folderPath: string) => {
+		if (folderPath === '' || folderPath === undefined || folderPath === null) return
+
+		bindTeardownIfNeeded()
+
+		clearPendingFSEvents()
+		closeAllWatchers()
+
+		currentRoot = folderPath
+
+		startWatcher(folderPath, folderPath)
+	})
+
+	// Lazily expand a subfolder. Open-close-open within the teardown delay is
+	// idempotent: it cancels the pending teardown rather than churning the
+	// watcher.
+	ipcMain.handle('expand-folder', async (_, subPath: string) => {
+		if (!subPath || !currentRoot) return
+
+		const existing = watchers.get(subPath)
+		if (existing) {
+			if (existing.pendingTeardownTimer) {
+				clearTimeout(existing.pendingTeardownTimer)
+				existing.pendingTeardownTimer = null
+			}
+			return
+		}
+
+		startWatcher(currentRoot, subPath)
+	})
+
+	// Lazily collapse a subfolder. The watcher stays alive for
+	// COLLAPSE_TEARDOWN_DELAY_MS so quick re-expand costs nothing; only after
+	// the delay elapses does the watcher close and its contribution to the
+	// aggregate visible-add counter get reclaimed. Collapsing the root is a
+	// no-op - root's watcher only closes when `fetch-folder-contents` is
+	// called again or on app teardown.
+	ipcMain.handle('collapse-folder', async (_, subPath: string) => {
+		if (!subPath) return
+
+		if (currentRoot && subPath === currentRoot) {
+			// Guard against nonsensical collapse-of-root - see design in #110.
+			console.debug('collapse-folder called on root; ignoring', subPath)
+			return
+		}
+
+		const entry = watchers.get(subPath)
+		if (!entry) return
+
+		if (entry.pendingTeardownTimer) {
+			// Already scheduled; keep the existing timer rather than resetting
+			// the countdown.
+			return
+		}
+
+		entry.pendingTeardownTimer = setTimeout(() => {
+			teardownWatcher(subPath)
+		}, COLLAPSE_TEARDOWN_DELAY_MS)
 	})
 
 	// Save a string to a file
@@ -257,4 +384,5 @@ export const addFSEventHandlers = (ipcMain: IpcMain, getMainWindow: () => Browse
 			console.error(error)
 		}
 	})
+
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,11 @@ import { electronAPI } from '@electron-toolkit/preload'
 //   - `collapse-folder(subPath)`       schedule watcher teardown (see
 //                                      COLLAPSE_TEARDOWN_DELAY_MS in
 //                                      `src/shared/constants.ts`)
+//   - `get-folder-contents({ folderPath, recursive, rootPath })`
+//                                      one-shot enumeration used by the
+//                                      plugin-facing `request-directory-
+//                                      contents` message; does not touch
+//                                      the watcher manager.
 // `electronAPI.ipcRenderer.invoke` accepts arbitrary channel strings, so no
 // per-channel type is required here.
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,16 @@
 import { contextBridge, webUtils } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 
+// The file explorer uses these renderer -> main IPC channels (handled in
+// `src/main/event-handlers/filesystem.ts`):
+//   - `fetch-folder-contents(root)`    open a root, close all watchers
+//   - `expand-folder(subPath)`         start a non-recursive watcher lazily
+//   - `collapse-folder(subPath)`       schedule watcher teardown (see
+//                                      COLLAPSE_TEARDOWN_DELAY_MS in
+//                                      `src/shared/constants.ts`)
+// `electronAPI.ipcRenderer.invoke` accepts arbitrary channel strings, so no
+// per-channel type is required here.
+
 // Custom APIs for renderer
 const api = {
   getFilePath: (file: File): string => {

--- a/src/renderer/src/components/MenuPanel/components/FileExplorer/components/DraggableEntry/DraggableEntry.tsx
+++ b/src/renderer/src/components/MenuPanel/components/FileExplorer/components/DraggableEntry/DraggableEntry.tsx
@@ -1,6 +1,6 @@
 import { useDraggable, useDroppable } from '@dnd-kit/core'
 import FileEntry from '../FileEntry/FileEntry'
-import { FileSystemNode } from '@renderer/contexts/DirectoryContext'
+import { DirectoryContext, FileSystemNode } from '@renderer/contexts/DirectoryContext'
 
 import styles from './DraggableEntry.module.css'
 import { MouseEvent, useContext, useEffect, useState } from 'react'
@@ -23,8 +23,33 @@ function DraggableEntry({
 	const type = node.children ? 'folder' : (node.name.endsWith('.tif') || node.name.endsWith('.tiff')) ? 'image' : 'file'
 	const isFolder = type === 'folder'
 	const isEmpty = !node.children || Object.keys(node.children).length === 0
+	// With lazy expansion an unopened folder starts with an empty children
+	// map. We still want to show a chevron so the user can expand it; the
+	// contents (or true emptiness) become visible once the main-side watcher
+	// streams the initial batch.
+	const showChevron = isFolder
 
 	const [isCollapsed, setIsCollapsed] = useState(true)
+
+	const { expandFolder, collapseFolder } = useContext(DirectoryContext)
+
+	// Dispatch expand/collapse to the main-side watcher manager alongside the
+	// existing visual toggle. Idempotent by design: main-side handlers no-op
+	// when the state already matches, and the visual toggle is instant while
+	// the fetch runs asynchronously.
+	const toggleCollapsed = (): void => {
+		setIsCollapsed((prev) => {
+			const next = !prev
+			if (isFolder) {
+				if (next) {
+					collapseFolder(node.path)
+				} else {
+					expandFolder(node.path)
+				}
+			}
+			return next
+		})
+	}
 
 	const { attributes, listeners, setNodeRef } = useDraggable({
 		id: node.path,
@@ -74,12 +99,12 @@ function DraggableEntry({
 			<div
 				className={isFolder ? (isEmpty ? styles.emptyFolder : styles.folder) : styles.file}
 			>
-				{!isEmpty && (
+				{showChevron && (
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
 						viewBox="0 0 320 512"
 						className={`${styles.collapseIcon} ${isCollapsed ? '' : styles.collapseIconOpen}`}
-						onClick={() => setIsCollapsed((prev) => !prev)}
+						onClick={toggleCollapsed}
 					>
 						<path
 							fill="currentColor"

--- a/src/renderer/src/contexts/DirectoryContext.tsx
+++ b/src/renderer/src/contexts/DirectoryContext.tsx
@@ -1,12 +1,15 @@
 import { joinWithSeparator } from '@renderer/interfaces/file'
 import { AlertContext } from '@renderer/contexts/AlertContext'
-import { JSX, createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { JSX, createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
+import { COLLAPSE_TEARDOWN_DELAY_MS } from '../../../shared/constants'
 
 export type DirectoryContextValue = {
 	nodes: NodeChildren
 	directoryPath: string | null
 	directoryName: string | null
 	setDirectory: (directory: string) => void
+	expandFolder: (subPath: string) => void
+	collapseFolder: (subPath: string) => void
 }
 
 export const DirectoryContext = createContext<DirectoryContextValue>(null as never)
@@ -28,7 +31,6 @@ type FSError = {
 	directoryPath: string
 	message: string
 	code?: string
-	depth: number
 	limit: number
 }
 
@@ -48,6 +50,11 @@ function DirectoryProvider({ children }: { children: React.ReactNode }): JSX.Ele
 	const [nodes, setNodes] = useState<NodeChildren>({})
 	const { addAlert } = useContext(AlertContext)
 
+	// Mirror the main-side collapse teardown: renderer-side state for a
+	// collapsed subfolder is pruned on the same delay. Re-expanding within
+	// the window cancels both timers so the existing slice stays.
+	const pendingCollapseTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
 	const setDirectory = useCallback(
 		(directory: string): void => {
 			// Make sure the directory is not empty
@@ -62,10 +69,50 @@ function DirectoryProvider({ children }: { children: React.ReactNode }): JSX.Ele
 			const directorySplit = directory.split(/[/\\]/)
 			setDirectoryName(directorySplit[directorySplit.length - 1])
 
-			// Clear the folder contents
+			// Clear the folder contents and any pending collapse timers -
+			// they refer to paths under the old root.
+			for (const timer of pendingCollapseTimers.current.values()) {
+				clearTimeout(timer)
+			}
+			pendingCollapseTimers.current.clear()
 			setNodes({})
 		},
 		[directoryPath]
+	)
+
+	const expandFolder = useCallback(
+		(subPath: string): void => {
+			if (!subPath) return
+
+			// Cancel a pending renderer-side prune if we re-expand in time.
+			const timer = pendingCollapseTimers.current.get(subPath)
+			if (timer) {
+				clearTimeout(timer)
+				pendingCollapseTimers.current.delete(subPath)
+			}
+
+			window.electron.ipcRenderer.invoke('expand-folder', subPath)
+		},
+		[]
+	)
+
+	const collapseFolder = useCallback(
+		(subPath: string): void => {
+			if (!subPath) return
+
+			// If a prune is already scheduled for this path, do not restart
+			// the timer.
+			if (pendingCollapseTimers.current.has(subPath)) return
+
+			window.electron.ipcRenderer.invoke('collapse-folder', subPath)
+
+			const timer = setTimeout(() => {
+				pendingCollapseTimers.current.delete(subPath)
+				setNodes((prev) => pruneSubtree(prev, subPath))
+			}, COLLAPSE_TEARDOWN_DELAY_MS)
+			pendingCollapseTimers.current.set(subPath, timer)
+		},
+		[]
 	)
 
 	useEffect(() => {
@@ -114,8 +161,27 @@ function DirectoryProvider({ children }: { children: React.ReactNode }): JSX.Ele
 		refreshDirectory()
 	}, [directoryPath])
 
+	// Clear any pending collapse timers on provider teardown.
+	useEffect(() => {
+		return (): void => {
+			for (const timer of pendingCollapseTimers.current.values()) {
+				clearTimeout(timer)
+			}
+			pendingCollapseTimers.current.clear()
+		}
+	}, [])
+
 	return (
-		<DirectoryContext.Provider value={{ nodes, directoryPath, directoryName, setDirectory }}>
+		<DirectoryContext.Provider
+			value={{
+				nodes,
+				directoryPath,
+				directoryName,
+				setDirectory,
+				expandFolder,
+				collapseFolder
+			}}
+		>
 			{children}
 		</DirectoryContext.Provider>
 	)
@@ -215,4 +281,42 @@ function handleFSEvent(nodes: NodeChildren, fsEvent: FSEvent): NodeChildren {
 	}
 
 	return nodesCopy
+}
+
+/**
+ * Drop the children of the folder identified by `subPath` from the nested
+ * `nodes` map, leaving the folder itself in place so its collapsed shell can
+ * still render. The folder is located by walking the tree and matching each
+ * node's absolute `path`; this keeps the reducer independent of the current
+ * root because `path` is the absolute filesystem path already.
+ */
+export function pruneSubtree(nodes: NodeChildren, subPath: string): NodeChildren {
+	if (!subPath) return nodes
+
+	let mutated = false
+	const walk = (children: NodeChildren): NodeChildren => {
+		let next: NodeChildren | null = null
+		for (const key of Object.keys(children)) {
+			const node = children[key]
+			if (node.path === subPath) {
+				if (node.children && Object.keys(node.children).length > 0) {
+					if (!next) next = { ...children }
+					next[key] = { ...node, children: {} }
+					mutated = true
+				}
+				continue
+			}
+			if (node.children) {
+				const walked = walk(node.children)
+				if (walked !== node.children) {
+					if (!next) next = { ...children }
+					next[key] = { ...node, children: walked }
+				}
+			}
+		}
+		return next ?? children
+	}
+
+	const result = walk(nodes)
+	return mutated ? result : nodes
 }

--- a/src/renderer/src/contexts/IFrameContext.tsx
+++ b/src/renderer/src/contexts/IFrameContext.tsx
@@ -1,15 +1,18 @@
 import {
 	IFrameMessage,
 	IFrameMessageSchema,
+	PluginNodeChildren,
 	ReadFileRequestSchema,
 	ReadFileResponse,
 	RegisterIFrameSchema,
+	RequestDirectoryContentsSchema,
 	SaveFileRequestSchema,
-	SendDirectoryContents
+	SendDirectoryContents,
+	SendDirectoryContentsResponse
 } from '@renderer/schemas/iframe-message-schema'
 import { safeParse } from 'valibot'
 import { readFile, writeFile } from '../interfaces/file'
-import { JSX, createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { JSX, createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { DirectoryContext } from '@renderer/contexts/DirectoryContext'
 
 export type IFrameContextValue = {
@@ -45,17 +48,28 @@ export function IFrameProvider({ children }: { children: React.ReactNode }): JSX
 		setIframes((prev) => new Map([...prev, [pluginName, source]]))
 	}
 
+	// Access the selected directory without broadcasting the full recursive file tree.
+	const { directoryPath, directoryName } = useContext(DirectoryContext)
+
+	// The request-directory-contents handler needs the *current* directory
+	// root at message time, not the value captured when the listener was
+	// registered. A ref keeps the closure stable while the listener effect
+	// runs once, matching the pattern used for the message listener below.
+	const directoryPathRef = useRef<string | null>(directoryPath)
+	useEffect(() => {
+		directoryPathRef.current = directoryPath
+	}, [directoryPath])
+
 	// Define the handlers for the different message types
 	const handlers: {
 		[key: string]: (source: MessageEventSource, data: IFrameMessage) => Promise<void>
 	} = {
 		'read-file': handleReadFileRequest,
 		'save-file': handleSaveFileRequest,
-		'register-plugin': updateIframes
+		'register-plugin': updateIframes,
+		'request-directory-contents': (source, data) =>
+			handleRequestDirectoryContentsRequest(source, data, directoryPathRef.current)
 	}
-
-	// Access the selected directory without broadcasting the full recursive file tree.
-	const { directoryPath, directoryName } = useContext(DirectoryContext)
 
 	const broadcast = useCallback(
 		(message: IFrameMessage): void => {
@@ -176,6 +190,151 @@ async function handleSaveFileRequest(_: MessageEventSource, data: IFrameMessage)
 		console.error(e)
 		return
 	}
+}
+
+async function handleRequestDirectoryContentsRequest(
+	source: MessageEventSource,
+	data: IFrameMessage,
+	directoryPath: string | null
+): Promise<void> {
+	const parseResult = safeParse(RequestDirectoryContentsSchema, data)
+
+	// If the request itself is malformed, we cannot correlate a requestId
+	// or trust the requested path. Report as `denied` with a null requestId
+	// so the plugin still learns something went wrong.
+	if (!parseResult.success) {
+		sendDirectoryContentsResponse(source, {
+			path: '',
+			nodes: {},
+			requestId: null,
+			error: { code: 'denied', message: 'Malformed request-directory-contents payload.' }
+		})
+		return
+	}
+
+	const { path: requestedPath, recursive, requestId } = parseResult.output.data
+	const correlationId = requestId ?? generateRequestId()
+
+	// No root selected: plugins that request before the user opens a folder
+	// get `denied` rather than a hanging promise.
+	if (!directoryPath) {
+		sendDirectoryContentsResponse(source, {
+			path: requestedPath,
+			nodes: {},
+			requestId: correlationId,
+			error: { code: 'denied', message: 'No directory is currently open.' }
+		})
+		return
+	}
+
+	// Path-traversal guard. `path.relative` returns `..`-prefixed results
+	// when the target escapes the base, and absolute results when the
+	// candidate is rooted on a different volume (Windows). Both are denied.
+	if (!isPathUnderRoot(directoryPath, requestedPath)) {
+		sendDirectoryContentsResponse(source, {
+			path: requestedPath,
+			nodes: {},
+			requestId: correlationId,
+			error: { code: 'denied', message: 'Path is outside the current directory root.' }
+		})
+		return
+	}
+
+	try {
+		const { nodes, truncated } = (await window.electron.ipcRenderer.invoke(
+			'get-folder-contents',
+			{ folderPath: requestedPath, recursive: recursive === true, rootPath: directoryPath }
+		)) as { nodes: PluginNodeChildren; truncated: boolean }
+
+		sendDirectoryContentsResponse(source, {
+			path: requestedPath,
+			nodes,
+			requestId: correlationId,
+			error: truncated
+				? {
+						code: 'limit',
+						message: `Enumeration truncated at aggregate cap; partial results returned.`,
+						truncated: true
+					}
+				: undefined
+		})
+	} catch (e) {
+		const err = e as { code?: string; message?: string }
+		const isNotFound = err?.code === 'ENOENT' || err?.code === 'ENOTDIR'
+
+		sendDirectoryContentsResponse(source, {
+			path: requestedPath,
+			nodes: {},
+			requestId: correlationId,
+			error: {
+				code: isNotFound ? 'not-found' : 'internal',
+				message: err?.message ?? 'Failed to read folder contents.'
+			}
+		})
+	}
+}
+
+function sendDirectoryContentsResponse(
+	source: MessageEventSource,
+	data: SendDirectoryContentsResponse['data']
+): void {
+	const response: SendDirectoryContentsResponse = {
+		type: 'send-directory-contents-response',
+		data
+	}
+	source.postMessage(response, { targetOrigin: '*' })
+}
+
+function isPathUnderRoot(rootPath: string, candidate: string): boolean {
+	// Reject empty candidates outright.
+	if (!candidate) return false
+
+	// A request for the root itself is allowed.
+	if (candidate === rootPath) return true
+
+	// Cross-volume checks on Windows: two absolute paths on different drives
+	// yield an absolute result from `path.relative`. Node's `path.posix` and
+	// `path.win32` behave the same way for this check on their respective
+	// separators; the renderer runs against the platform-native module.
+	// We use browser-safe string checks rather than importing 'path' in the
+	// renderer bundle.
+	const normalizedRoot = rootPath.replace(/[\\/]+$/, '')
+	const rel = getPathRelative(normalizedRoot, candidate)
+	if (rel === null) return false
+	if (rel === '' || rel === '.') return true
+	if (rel.startsWith('..')) return false
+	// Absolute-looking segment means Windows drive change (e.g. `D:\foo`).
+	if (/^[A-Za-z]:[\\/]/.test(rel)) return false
+	if (rel.startsWith('/') || rel.startsWith('\\')) return false
+	return true
+}
+
+// Minimal string-based relative computation that avoids pulling Node's
+// `path` module into the renderer. Handles both POSIX and Windows-style
+// separators. Returns `null` for pathological inputs (e.g. differing drive
+// letters), which the caller treats as a deny.
+function getPathRelative(rootPath: string, candidate: string): string | null {
+	const rootNorm = rootPath.replace(/\\/g, '/')
+	const candNorm = candidate.replace(/\\/g, '/')
+
+	// Windows drive-letter mismatch: reject.
+	const rootDrive = /^([A-Za-z]:)/.exec(rootNorm)?.[1]?.toUpperCase()
+	const candDrive = /^([A-Za-z]:)/.exec(candNorm)?.[1]?.toUpperCase()
+	if (rootDrive && candDrive && rootDrive !== candDrive) return null
+
+	if (candNorm === rootNorm) return ''
+	if (candNorm.startsWith(rootNorm + '/')) {
+		return candNorm.slice(rootNorm.length + 1)
+	}
+	return '..'
+}
+
+function generateRequestId(): string {
+	// Best-effort correlation id when the plugin didn't supply one. Not
+	// security-sensitive; a short random suffix is enough.
+	const g = globalThis as unknown as { crypto?: { randomUUID?: () => string } }
+	if (g.crypto?.randomUUID) return g.crypto.randomUUID()
+	return `req-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
 }
 
 function isAllowedOrigin(allowedHostnames: string[], origin: string): boolean {

--- a/src/renderer/src/schemas/iframe-message-schema.ts
+++ b/src/renderer/src/schemas/iframe-message-schema.ts
@@ -1,4 +1,18 @@
-import { any, includes, object, pipe, string, InferOutput, nullable } from 'valibot'
+import {
+	any,
+	boolean,
+	includes,
+	lazy,
+	object,
+	optional,
+	picklist,
+	pipe,
+	record,
+	string,
+	InferOutput,
+	nullable,
+	GenericSchema
+} from 'valibot'
 
 export const IFrameMessageSchema = object({
 	type: string(),
@@ -57,6 +71,56 @@ export const SaveFileRequestSchema = object({
 })
 
 export type SaveFileRequest = InferOutput<typeof SaveFileRequestSchema>
+
+// A path-keyed nested map of `FileSystemNode` matching the renderer's
+// `DirectoryContext.NodeChildren` shape. Defined recursively via a lazy
+// object schema (valibot cannot self-reference statically).
+export type PluginFileSystemNode = {
+	name: string
+	path: string
+	children?: { [key: string]: PluginFileSystemNode }
+}
+
+export type PluginNodeChildren = { [key: string]: PluginFileSystemNode }
+
+const PluginFileSystemNodeSchema: GenericSchema<PluginFileSystemNode> = object({
+	name: string(),
+	path: string(),
+	children: optional(
+		lazy(() => record(string(), PluginFileSystemNodeSchema))
+	)
+})
+
+const PluginNodeChildrenSchema = record(string(), PluginFileSystemNodeSchema)
+
+export const RequestDirectoryContentsSchema = object({
+	type: pipe(string(), includes('request-directory-contents')),
+	data: object({
+		path: string('Path is required'),
+		recursive: optional(boolean()),
+		requestId: optional(string())
+	})
+})
+
+export type RequestDirectoryContents = InferOutput<typeof RequestDirectoryContentsSchema>
+
+export const SendDirectoryContentsResponseSchema = object({
+	type: pipe(string(), includes('send-directory-contents-response')),
+	data: object({
+		path: string(),
+		nodes: PluginNodeChildrenSchema,
+		requestId: nullable(string()),
+		error: optional(
+			object({
+				code: picklist(['denied', 'not-found', 'limit', 'internal'] as const),
+				message: string(),
+				truncated: optional(boolean())
+			})
+		)
+	})
+})
+
+export type SendDirectoryContentsResponse = InferOutput<typeof SendDirectoryContentsResponseSchema>
 
 export const SendNeuroglancerJSONSchema = object({
 	type: pipe(string(), includes('send-neuroglancer-json')),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,0 +1,13 @@
+// Cross-surface constants shared between the Electron main process and the
+// renderer. Keep this file dependency-free so both bundles can import it
+// without pulling in Node- or DOM-specific modules.
+
+/**
+ * How long to wait after the renderer collapses a folder before the main
+ * process closes the watcher on that folder and the renderer prunes the
+ * matching subtree from state. If the user re-expands the folder before this
+ * timer elapses, both teardowns are cancelled and existing state is kept.
+ *
+ * See documentation/docs/reference/technical-constants.md for the rationale.
+ */
+export const COLLAPSE_TEARDOWN_DELAY_MS = 30_000

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
 	"extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
-	"include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*"],
+	"include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*", "src/shared/**/*"],
 	"compilerOptions": {
 		"composite": true,
 		"types": ["electron-vite/node"]

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -4,7 +4,8 @@
 		"src/renderer/src/env.d.ts",
 		"src/renderer/src/**/*",
 		"src/renderer/src/**/*.tsx",
-		"src/preload/*.d.ts"
+		"src/preload/*.d.ts",
+		"src/shared/**/*"
 	],
 	"compilerOptions": {
 		"composite": true,
@@ -13,6 +14,9 @@
 		"paths": {
 			"@renderer/*": [
 				"src/renderer/src/*"
+			],
+			"@shared/*": [
+				"src/shared/*"
 			]
 		}
 	}


### PR DESCRIPTION
Closes #111. Refs #102.

## Stack notice

**This PR stacks on [#112](https://github.com/ChengLabResearch/ouroboros/pull/112) (which closes #110).** Please merge #112 first; this branch is cut from `lazy-file-explorer` and depends on the shared `@shared/constants` alias, the lazy watcher manager, and the `expand-folder` / `collapse-folder` IPC channels landing there. Once #112 is in, this branch either fast-forwards onto `main` cleanly or picks up a trivial rebase.

## Summary

Adds an explicit request/response API to the plugin iframe surface so plugins can walk the current directory root on demand:

- **`request-directory-contents`** (plugin -> provider): `{ path, recursive?, requestId? }`. `recursive` defaults to `false`. `requestId` is optional; when omitted the provider generates one and echoes it back on the response so plugins can still correlate.
- **`send-directory-contents-response`** (provider -> requesting iframe only): `{ path, nodes, requestId, error? }`. `nodes` is a path-keyed nested map of `{ name, path, children? }`, matching the shape the pre-#106 broadcast used, so plugins get a drop-in replacement for the empty tree they've been receiving since #106.

The existing `send-directory-contents { directoryPath, directoryName, nodes: {} }` broadcast on root change is unchanged — plugins still get root metadata for free and use the new request API when they need the tree.

Error codes on the response:
- `denied` — path outside the current root, no root open, or the request itself was malformed.
- `not-found` — path does not exist / is not a directory (`ENOENT` / `ENOTDIR`).
- `limit` — enumeration hit the aggregate cap. `truncated: true` is set and `nodes` holds the partial result.
- `internal` — anything else; `message` carries the underlying error string.

## Implementation notes

- **Response wiring is point-to-point.** Responses go to `source.postMessage(...)` on the requesting iframe's `MessageEventSource`, never through the broadcast helper. Verified by inspection; a two-iframe integration check would confirm.
- **Path-traversal guard.** `handleRequestDirectoryContentsRequest` computes a relative path from the current root without pulling Node's `path` module into the renderer bundle (small helper `getPathRelative` that normalizes separators and detects Windows drive-letter mismatches). `..` escapes and cross-drive references are denied.
- **Ignore rules match the watcher.** `src/main/event-handlers/filesystem.ts` factored `shouldIgnorePathAgainstRoot(rootPath, targetPath)` out to a top-level helper. Both the watcher factory and the new one-shot `getFolderContents` use it, so plugins cannot bypass dotfile / `node_modules` / `__pycache__` / `venv` filtering.
- **Enumeration is one-shot, not watcher-driven.** The new `get-folder-contents` IPC handler does a single `readdir` walk against `fs/promises` and never touches the watcher manager. Recursion is depth-first and bounded by `FILE_EXPLORER_WATCH_LIMIT` reused as the aggregate enumeration cap (justified inline: keeps plugin and user paths bounded by the same visible-path budget; the enumeration count is per-request and does not accumulate across requests, so a plugin cannot starve the file explorer). If the cap is hit mid-walk, the walk stops and the response comes back with `error.code: 'limit'`, `error.truncated: true`, and whatever `nodes` were already gathered.
- **Directory read closure.** `IFrameContext` uses a `directoryPathRef` so the handler always sees the current `directoryPath` at message time, not whatever was captured when the message listener effect ran.
- **Malformed-request response.** When the request fails valibot parsing, the handler still emits an error response (with a `null` requestId) rather than silently dropping — plugins get some signal that their request was rejected.

## Acceptance criteria (from #111)

- [x] Plugin iframe can `postMessage({ type: 'request-directory-contents', data: { path } })` and receive that folder's direct entries. (New handler wired; documented request/response example in `documentation/docs/guide/plugins.md`.)
- [x] Recursive requests return the whole subtree (bounded by watch limit; truncation surfaced via `error`). (`recursive: true` triggers depth-first walk; `error.code: 'limit'` with `truncated: true` when the aggregate cap is hit.)
- [x] Only the requesting iframe receives the response (verified by inspection; response uses `source.postMessage(...)` directly rather than the `broadcast` helper).
- [x] Backward compat: existing autoseg / neuroglancer plugins continue to work unchanged. (autoseg does not use parent-window messaging; neuroglancer still receives the root broadcast for the path/name — see companion follow-up below for the plugin-side migration that consumes the new API.)
- [x] `documentation/docs/guide/plugins.md` documents the new message types with a minimal example.
- [x] `npm run typecheck` passes.

## Companion migration follow-up

- **`ChengLabResearch/neuroglancer-plugin#9`** — filed alongside this PR. The plugin still consumes the `send-directory-contents` broadcast's `nodes` field, which has been `{}` since #106. This PR unblocks the plugin by giving it an API to fetch on demand; the plugin itself still needs the migration described in that issue.

## Related follow-up on this repo

- **#113** — pre-existing path-traversal gap in `read-file` / `save-file` iframe handlers. Not introduced by this PR; called out separately because #111's scope was the new API, and adding the guard to the existing handlers would have widened the diff. Fix sketch is in the issue.

## Reviewer smoke checklist (manual)

Automation host has no display, so `npm run dev` was not attempted. To verify manually after #112 lands:

1. Apply the `neuroglancer-plugin#9` migration locally (or check out a branch that does), load the neuroglancer plugin against a mid-size folder, and confirm the LoadFile pane now populates with the folder's contents.
2. Walk into a subfolder from the plugin's tree UI and confirm entries appear.
3. From the plugin iframe's DevTools console, issue a request for a path outside the current root, e.g.:
   ```js
   window.parent.postMessage({ type: 'request-directory-contents', data: { path: '/', recursive: false, requestId: 'test-1' } }, '*')
   window.addEventListener('message', e => e.data?.type === 'send-directory-contents-response' && console.log(e.data.data))
   ```
   Expected: `error.code === 'denied'`.
4. From the same console, issue a recursive request against a very large tree (or lower `FILE_EXPLORER_WATCH_LIMIT` locally for the test). Expected: `error.code === 'limit'`, `error.truncated === true`, and `nodes` holds the partial subtree collected before the cap hit.

## Verification commands

```
npm ci                # completed
npm run typecheck     # passes (both tsconfig.node.json and tsconfig.web.json)
npm run lint          # fails with pre-existing ESLint 9 config drift; see below
```

## Blockers / pre-existing issues

- `npm run lint` fails with `ESLint couldn't find an eslint.config.(js|mjs|cjs) file` — the pre-existing ESLint 9 config drift called out in #109 and #112. Not addressed here.
- If #112 rebases before this PR merges, this branch will need a matching rebase. Guardrail: no force-push planned on this branch until the stack lands.

## Files changed

- `src/renderer/src/schemas/iframe-message-schema.ts` — new `RequestDirectoryContentsSchema` and `SendDirectoryContentsResponseSchema`; recursive `PluginFileSystemNodeSchema` via `lazy`.
- `src/renderer/src/contexts/IFrameContext.tsx` — `handleRequestDirectoryContentsRequest` handler, ref-backed directory tracking, traversal guard.
- `src/main/event-handlers/filesystem.ts` — `get-folder-contents` IPC handler backed by top-level `getFolderContents`; shared `shouldIgnorePathAgainstRoot` helper.
- `src/preload/index.ts` — documenting comment for the new IPC channel.
- `documentation/docs/guide/plugins.md` — new "Requesting Directory Contents" section.
- `documentation/docs/reference/technical-constants.md` — `FILE_EXPLORER_WATCH_LIMIT` entry extended with its second (enumeration cap) role; plugin directory broadcast section points at the new API.