### PR TITLE
Switch mainWindow to did-finish-load to address wayland non-start

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,7 +42,7 @@ function createWindow(): void {
 
 	Menu.setApplicationMenu(makeMenu(mainWindow))
 
-	mainWindow.on('ready-to-show', () => {
+	mainWindow.webContents.on('did-finish-load', () => {
 		mainWindow.maximize()
 		mainWindow.focus()
 	})
@@ -71,9 +71,11 @@ function createWindow(): void {
 	} else {
 		startMainServerProduction()
 	}
+	console.info('Started Main Server')
 
 	// Start the docker volume server
 	startVolumeServer()
+	console.info('Started Volume Server')
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
Closes #116 

Switches mainWindow to did-finish-load as ready-to-show doesn't fire on Wayland.