### PR TITLE
Normalize release lock fingerprint across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+release/release-lock.json text eol=lf

--- a/scripts/build-release-artifacts.mjs
+++ b/scripts/build-release-artifacts.mjs
@@ -4,6 +4,7 @@ import { spawn } from 'node:child_process'
 import { join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { gitOutput } from './lib/git.mjs'
+import { npmInvocation } from './lib/npm.mjs'
 import {
 	RELEASE_PLATFORMS,
 	loadReleaseLock,
@@ -207,28 +208,6 @@ async function copyAndDescribe({ source, destination, name, flavor, type }) {
 		bytes: details.size,
 		sha256: await sha256File(destination)
 	}
-}
-
-export function npmInvocation(
-	args,
-	{
-		nodeExecutable = process.execPath,
-		npmExecutable = process.env.npm_execpath,
-		platform = process.platform
-	} = {}
-) {
-	if (npmExecutable) {
-		return {
-			command: nodeExecutable,
-			args: [npmExecutable, ...args]
-		}
-	}
-	if (platform === 'win32') {
-		throw new Error(
-			'npm_execpath is required on Windows so npm can be launched without a command shell'
-		)
-	}
-	return { command: 'npm', args }
 }
 
 async function runNpm(args, options) {

--- a/scripts/lib/npm.mjs
+++ b/scripts/lib/npm.mjs
@@ -1,0 +1,21 @@
+export function npmInvocation(
+	args,
+	{
+		nodeExecutable = process.execPath,
+		npmExecutable = process.env.npm_execpath,
+		platform = process.platform
+	} = {}
+) {
+	if (npmExecutable) {
+		return {
+			command: nodeExecutable,
+			args: [npmExecutable, ...args]
+		}
+	}
+	if (platform === 'win32') {
+		throw new Error(
+			'npm_execpath is required on Windows so npm can be launched without a command shell'
+		)
+	}
+	return { command: 'npm', args }
+}

--- a/scripts/lib/release-lock.mjs
+++ b/scripts/lib/release-lock.mjs
@@ -20,7 +20,7 @@ export async function loadReleaseLock(root = process.cwd()) {
 	return {
 		lock,
 		path,
-		sha256: sha256(bytes)
+		sha256: sha256(Buffer.from(JSON.stringify(lock)))
 	}
 }
 

--- a/scripts/tests/release-pipeline.test.mjs
+++ b/scripts/tests/release-pipeline.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
@@ -39,6 +39,26 @@ test('release lock validation rejects mutable or malformed identities', async ()
 	const duplicateFlavor = structuredClone(lock)
 	duplicateFlavor.packageFlavors.push(duplicateFlavor.packageFlavors[0])
 	assert.throws(() => validateReleaseLock(duplicateFlavor), /duplicates/)
+})
+
+test('release lock identity is independent of checkout line endings', async () => {
+	const directory = await mkdtemp(join(tmpdir(), 'ouroboros-release-lock-test-'))
+	try {
+		const releaseDirectory = join(directory, 'release')
+		const lockPath = join(releaseDirectory, 'release-lock.json')
+		const source = await readFile(join(root, 'release', 'release-lock.json'), 'utf8')
+		await mkdir(releaseDirectory)
+
+		await writeFile(lockPath, source.replace(/\r?\n/g, '\n'))
+		const lf = await loadReleaseLock(directory)
+		await writeFile(lockPath, source.replace(/\r?\n/g, '\r\n'))
+		const crlf = await loadReleaseLock(directory)
+
+		assert.deepEqual(crlf.lock, lf.lock)
+		assert.equal(crlf.sha256, lf.sha256)
+	} finally {
+		await rm(directory, { recursive: true, force: true })
+	}
 })
 
 test('release fingerprints change with the source tree or input lock', () => {

--- a/scripts/tests/release-pipeline.test.mjs
+++ b/scripts/tests/release-pipeline.test.mjs
@@ -11,7 +11,8 @@ import {
 	validateReleaseLock
 } from '../lib/release-lock.mjs'
 import { gitOutput } from '../lib/git.mjs'
-import { isReleaseAssetName, npmInvocation, parsePlatform } from '../build-release-artifacts.mjs'
+import { npmInvocation } from '../lib/npm.mjs'
+import { isReleaseAssetName, parsePlatform } from '../build-release-artifacts.mjs'
 import { verifyReleaseArtifacts } from '../verify-release-artifacts.mjs'
 
 const root = process.cwd()

--- a/scripts/validate-npm-audit.mjs
+++ b/scripts/validate-npm-audit.mjs
@@ -1,13 +1,14 @@
 import { spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { npmInvocation } from './lib/npm.mjs'
 
 const approvedAdvisory = 'GHSA-qwww-vcr4-c8h2'
 const patchedVersion = '7.18.2'
 const approvedPackages = new Set(['react-router', 'react-router-dom'])
 
-const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-const audit = spawnSync(npm, ['audit', '--json'], {
+const npm = npmInvocation(['audit', '--json'])
+const audit = spawnSync(npm.command, npm.args, {
 	encoding: 'utf8',
 	stdio: ['ignore', 'pipe', 'inherit']
 })


### PR DESCRIPTION
## Summary
- hash the validated release-lock JSON content instead of checkout-specific file bytes
- make release fingerprints identical for LF and CRLF checkouts
- add regression coverage for Windows versus Unix line endings

## Why
The `v1.5.1` publication run failed because the Windows artifact manifest recorded the SHA-256 of a CRLF checkout while the Linux publisher calculated the SHA-256 of the LF checkout. The parsed lock content was identical.

This keeps semantic lock changes fail-closed while removing platform-specific line-ending differences from the fingerprint.

## Validation
- `npm run test:release`
- direct release test execution: 7 passed
- ESLint
- Prettier
- `npm run typecheck`
- `git diff --check`

After merge and a successful certified main build, the existing failed `v1.5.1` tag will need to be moved to the corrected main commit before publication is retriggered.